### PR TITLE
Redshift Serverless を前提とした学習用DPC基盤設計のコスト最適化

### DIFF
--- a/docs/09_operations.md
+++ b/docs/09_operations.md
@@ -1,27 +1,23 @@
 # DPC 学習基盤 観測・運用設計
 
 ## 目的
-Redshift を中心とした学習基盤の監視指標、WLM 設定、アラート、メンテナンス手順を定義する。
+Redshift Serverless を中心とした学習基盤の監視指標、リソースポリシー、アラート、メンテナンス手順を定義する。サーバーレス構成で費用を抑えつつ、必要な可観測性を確保する。
 
-## WLM 設計
-| キュー名 | 用途 | スロット | Concurrency Scaling | 優先度 | 備考 |
-| --- | --- | --- | --- | --- | --- |
-| `batch` | 日次 ELT（dbt run, COPY） | 50% | 有効 | 高 | Step Functions からのみ実行。クエリキュータイムアウト 2 時間。 |
-| `adhoc` | 学習者の分析クエリ | 30% | 無効 | 中 | 同時実行 5 件まで、タイムアウト 30 分。 |
-| `admin` | DQ チェック、メンテ | 20% | 有効 | 最高 | Lambda (DQ, VACUUM) 専用。 |
-
-- Short Query Acceleration (SQA) を有効化し、`admin` キューからの短時間クエリを優先。
-- WLM パラメータ: `max_concurrency`、`user_group` マッピングを IAM ロール単位で設定。
+## Redshift Serverless キャパシティ設計
+- **ベース RPU**: 8 RPU（最小値）で起動。バッチ処理時のみスケーリングし、30 分アイドルで自動一時停止。
+- **最大 RPU**: 32 RPU。Step Functions からの大規模 dbt 実行時にのみ増加を許可。
+- **ワークグループポリシー**: `workgroup-usage-limit` を設定し、月次上限コストを可視化。閾値 80% 到達で通知。
+- **クエリモニタリングルール (QMR)**: `execution_time > 600` 秒のクエリにタグ付けし、長時間クエリを通知。必要に応じて `abort` アクションを設定。
 
 ## 監視メトリクス
 | カテゴリ | メトリクス | 説明 | 閾値 | アクション |
 | --- | --- | --- | --- | --- |
 | 取込遅延 | `ELTExecutionDelay` (自前カスタム) | 最終成功時刻との差分 (分) | > 90 分 | 通知後に Step Functions 再実行。 |
 | COPY 失敗 | CloudWatch Metric Filter (`CopyErrorCount`) | `stl_load_errors` 件数 | >=1 | バッチ失敗、担当者呼び出し。 |
-| クエリ失敗率 | `WLMRejectedQueries` / `WLMAttemptedQueries` | 直近 1 時間 | > 5% | WLM 再調整、SQL レビュー。 |
-| スロット逼迫 | `WLMQueueLength` | `batch` キューの待機数 | > 10 | クエリ優先順位見直し。 |
-| テーブルスキュー | `table_skew_percent` (system table) | ディストリビューション偏り | > 20% | DISTKEY 見直し。 |
-| ストレージ使用 | `RedshiftStorageCapacity` | RA3 ストレージ使用率 | > 80% | VACUUM / Spectrum 退避。 |
+| クエリ失敗率 | `FailedQueryCount / TotalQueryCount` (Serverless) | 直近 1 時間 | > 5% | SQL レビュー・再実行。 |
+| RPU 使用率 | `RPUConsumption` | 現在の消費 RPU | > 28 RPU が 5 分継続 | クエリ負荷を確認し、必要ならモデル調整。 |
+| 自動一時停止 | `ServerlessDatabaseStatus` | `PAUSED` である時間 | < 30% | 無停止期間が長い場合はスケジュール見直し。 |
+| ディストリビューション | `table_skew_percent` (system table) | ディストリビューション偏り | > 20% | DISTKEY 見直し。 |
 
 ## CloudWatch ダッシュボード構成
 ```json
@@ -34,10 +30,10 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
       "width": 12,
       "height": 6,
       "properties": {
-        "title": "Redshift WLM Queue Length",
+        "title": "RPU Consumption",
         "metrics": [
-          ["AWS/Redshift", "WLMQueueLength", "QueueName", "batch", {"stat": "Sum"}],
-          ["AWS/Redshift", "WLMQueueLength", "QueueName", "adhoc", {"stat": "Sum"}]
+          ["AWS/Redshift", "RPUConsumption", "Workgroup", "dpc-learning"],
+          ["AWS/Redshift", "RPUCapacity", "Workgroup", "dpc-learning"]
         ],
         "period": 300,
         "stat": "Average"
@@ -50,9 +46,10 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
       "width": 12,
       "height": 6,
       "properties": {
-        "title": "Concurrency Scaling Usage",
+        "title": "Query Success vs Fail",
         "metrics": [
-          ["AWS/Redshift", "ConcurrencyScalingActiveClusters", "ClusterIdentifier", "dpc-learning"]
+          ["AWS/Redshift", "SuccessfulQueryCount", "Workgroup", "dpc-learning"],
+          ["AWS/Redshift", "FailedQueryCount", "Workgroup", "dpc-learning"]
         ],
         "period": 300,
         "stat": "Average"
@@ -67,7 +64,7 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
       "properties": {
         "title": "Storage Utilization",
         "metrics": [
-          ["AWS/Redshift", "PercentageDiskSpaceUsed", "ClusterIdentifier", "dpc-learning"]
+          ["AWS/Redshift", "UsedStorage", "Namespace", "dpc-learning"]
         ],
         "period": 3600,
         "stat": "Average"
@@ -95,7 +92,7 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
       "width": 24,
       "height": 6,
       "properties": {
-        "query": "SOURCE '/aws/redshift/cluster/dpc-learning' | fields @timestamp, @message | filter @message like 'ERROR' | sort @timestamp desc | limit 20",
+        "query": "SOURCE '/aws/redshift-serverless/workgroup/dpc-learning' | fields @timestamp, @message | filter @message like 'ERROR' | sort @timestamp desc | limit 20",
         "title": "Redshift Error Logs"
       }
     }
@@ -108,16 +105,16 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
 | --- | --- | --- |
 | `Alert-ELT-Delay` | `ELTExecutionDelay > 90` 分が 2 データポイント連続 | Slack `#dpc-alerts`, PagerDuty |
 | `Alert-COPY-Error` | `CopyErrorCount >= 1` | Slack, OpsGenie |
-| `Alert-Storage-High` | `PercentageDiskSpaceUsed > 80%` を 3 回連続 | Slack, メール |
-| `Alert-WLM-Queue` | `WLMQueueLength (batch) > 10` が 10 分継続 | Slack |
-| `Alert-Query-Failure` | `WLMRejectedQueries/WLMAttemptedQueries > 0.05` | Slack |
+| `Alert-Storage-High` | `UsedStorage` が 90% 以上 | Slack, メール |
+| `Alert-RPU-Spike` | `RPUConsumption > 28` が 5 分継続 | Slack |
+| `Alert-Query-Failure` | `FailedQueryCount` が連続 3 回増加 | Slack |
 
 通知は SNS トピック `arn:aws:sns:ap-northeast-1:<account>:dpc-alerts` 経由。
 
 ## メンテナンス手順
 ### 自動実行
-- `ANALYZE`：Step Functions バッチ内で `analyze compression` とは別に `ANALYZE stage.*` を実行。
-- `VACUUM`：週次（日曜 04:00）で `VACUUM REINDEX` を実行。時間が掛かる場合は `VACUUM DELETE` のみ自動。
+- `ANALYZE`：Step Functions バッチ内で `ANALYZE` を実行。
+- `VACUUM`：週次（日曜 04:00）で `VACUUM` を実行。Serverless でも手動 VACUUM が必要。
 - `ANALYZE COMPRESSION`：月次で `ANALYZE COMPRESSION` を実行し推奨エンコードを確認。
 
 ### 手動トリガー条件
@@ -125,7 +122,7 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
 | --- | --- |
 | `VACUUM FULL` | `stv_blocklist` で 20% 以上の未使用領域を検知した場合 |
 | `ANALYZE` 再実行 | 大量データロード（1 億件以上）後、統計古さが懸念される場合 |
-| `Resize Cluster` | ストレージ使用率 90% 超 or WLM 待機が日常化 |
+| `Adjust RPU Limit` | `RPUConsumption` が頻繁に上限に達する場合 |
 
 ## Runbook
 1. **一次切り分け**
@@ -136,17 +133,17 @@ Redshift を中心とした学習基盤の監視指標、WLM 設定、アラー�
    - `COPY` エラー: 原因ファイルを S3 から削除/再アップロードし、Step Functions を再実行。
    - `dbt` 失敗: ログを確認し SQL 修正。必要に応じ `dbt run --select <model>` を手動実行後、全体を再実行。
    - ストレージ逼迫: `UNLOAD` 済み古いデータを Spectrum へ退避し、`VACUUM` を実行。
-   - WLM キュー過多: 一時的に `adhoc` キューを停止し `batch` を優先。
+   - RPU スパイク: 実行中クエリを特定し、必要に応じて QMR でキャンセル。
 3. **事後対応**
    - Confluence / Notion に事象記録。
    - DQ 結果およびエラーサマリを共有。
 
 ## 決定事項 / 未決事項
 - **決定事項**
-  - WLM を `batch` / `adhoc` / `admin` の 3 キューに分割し、ELT 優先度を確保する。
-  - CloudWatch ダッシュボードで WLM、ストレージ、ELT 遅延を可視化し、SNS を通じてアラートを発報する。
+  - Redshift Serverless のベース RPU を 8、最大 RPU を 32 に設定し、月次上限アラートを構成する。
+  - CloudWatch ダッシュボードで RPU 消費、クエリ成功率、ストレージ、ELT 遅延を可視化し、SNS を通じてアラートを発報する。
   - `ANALYZE`, `VACUUM`, `ANALYZE COMPRESSION` の実行スケジュールを定義し、定期メンテナンスを自動化する。
 - **未決事項**
   - `ELTExecutionDelay` の算出方法（Step Functions 実行完了時刻 vs mart テーブル更新時刻）の詳細設計が必要。
-  - WLM スロット比率 (50/30/20) の妥当性検証を実データ負荷で実施する必要がある。
+  - RPU 上限 32 の妥当性を学習データ量で検証し、必要なら再設定する。
   - Runbook をどのプラットフォームで管理するか（Confluence vs Notion）の決定が必要。

--- a/docs/10_performance.md
+++ b/docs/10_performance.md
@@ -1,7 +1,7 @@
 # DPC 学習基盤 パフォーマンス設計（物理最適化）
 
 ## 目的
-代表的な分析クエリに対する Redshift 物理設計の根拠と最適化手法を定義し、DIST/SORT 設定やマテリアライズドビュー (MV)、CTAS 活用方針を明確にする。
+代表的な分析クエリに対する Redshift Serverless 上での物理設計の根拠と最適化手法を定義し、DIST/SORT 設定やマテリアライズドビュー (MV)、CTAS 活用方針を明確にする。サーバーレスでもディストリビューション/ソート設計は有効であり、RPU 消費を抑えるための最適化を整理する。
 
 ## テーブル別 DIST/SORT 根拠
 | テーブル | DIST 設定 | SORT 設定 | 根拠 |
@@ -103,8 +103,9 @@ ORDER BY facility_cd, year_month;
 
 ## その他最適化
 - Spectrum 利用: 過去 5 年以上のデータを Parquet 化し S3 に配置、Redshift Spectrum 外部テーブルで参照。`UNLOAD` + `CREATE EXTERNAL TABLE` を活用。
-- `result_cache`: 繰返し同一クエリを実行する QuickSight には Result Cache を有効化。
-- `statement_timeout`: `adhoc` キューで 30 分を設定し過負荷クエリを防止。
+- `result_cache`: 繰返し同一クエリを実行する QuickSight には Result Cache を有効化し、RPU 消費を抑制。
+- `statement_timeout`: ワークグループのパラメータで 30 分を設定し、過負荷クエリを防止。
+- `serverless_pause`: 学習期間以外はワークグループを手動停止し、不要な RPU 課金を避ける。
 
 ## 決定事項 / 未決事項
 - **決定事項**


### PR DESCRIPTION
## 概要
- Redshift Serverless を採用する構成に刷新し、NAT や専用 VPC を廃止して学習用コストを抑制
- ネットワークと運用設計をサーバーレス前提に再整理し、RPU モニタリングや Data API 中心の権限制御を明記
- パフォーマンス指針を Serverless での RPU 最適化観点に更新

## テスト
- 実施せず（ドキュメントのみ）

------
https://chatgpt.com/codex/tasks/task_e_68f73bac452c8329b6eaad0707317e41