### PR TITLE
Add helper scripts for manual DPC raw uploads

### DIFF
--- a/docs/manual_ingestion.md
+++ b/docs/manual_ingestion.md
@@ -1,0 +1,67 @@
+# 手動アップロード運用ガイド
+
+このガイドでは、学習用 DPC データを S3 `raw/` プレフィックスへ配置するための手順を説明します。`docs/03_s3_naming.md` の命名規約に沿ってファイルを整理し、マニフェストを生成するために `tools/prepare_upload.sh` と `tools/generate_manifest.py` を利用します。
+
+## 前提条件
+- AWS CLI で対象バケットへアップロードできる IAM 認証情報を保有していること。
+- ローカルにアップロード対象の DPC サンプルファイルが存在すること。
+- Python 3.8 以上と Bash が利用できること。
+
+## 1. ディレクトリとファイル名の整備
+`tools/prepare_upload.sh` はファイルを命名規約に合わせて配置する補助スクリプトです。
+
+```bash
+# 例: 131000123 施設の 2025 年 4 月分 y1 を整備
+./tools/prepare_upload.sh \
+  --facility 131000123 \
+  --month 2025-04 \
+  --file-type y1 \
+  --input ~/Downloads/y1_202504.csv \
+  --dest ./upload_work
+```
+
+実行すると、`upload_work/raw/yyyymm=2025-04/y1/131000123_202504_y1_001.csv` のような構造が作成されます。既存ファイルがある場合は連番を自動採番します。`--dry-run` を指定するとコピーを行わずに結果だけ確認できます。
+
+## 2. `_manifest.json` の生成
+`tools/generate_manifest.py` で監査マニフェストを作成します。
+
+```bash
+./tools/generate_manifest.py upload_work/raw/yyyymm=2025-04/y1 \
+  --facility 131000123 \
+  --yyyymm 202504 \
+  --file-type y1 \
+  --data-file upload_work/raw/yyyymm=2025-04/y1/131000123_202504_y1_001.csv \
+  --has-header \
+  --notes "2025年度1Q診療分"
+```
+
+- `--data-file` を指定するとファイルのレコード数とハッシュ値を自動算出します。ハッシュアルゴリズムは既定で `SHA256` です。別ファイルを集計した場合は `--records` や `--hash-value` を手動で渡せます。
+- `_manifest.json` が既に存在する場合は `--overwrite` を付与してください。
+
+生成されたマニフェストは命名規約に準拠した JSON になり、Lambda の検証にそのまま利用できます。
+
+## 3. S3 へのアップロード
+準備したディレクトリを AWS CLI でアップロードします。
+
+```bash
+aws s3 cp ./upload_work/raw/ s3://dpc-learning-data-dev/raw/ --recursive
+```
+
+アップロード後はファイル数と `_manifest.json` の `records` が整合しているかを確認します。
+
+```bash
+aws s3 ls s3://dpc-learning-data-dev/raw/yyyymm=2025-04/y1/
+```
+
+## 4. Step Functions の手動実行
+S3 への配置後、Step Functions で `validate_manifest` ステップを手動起動し、検証結果を確認してください。失敗時は CloudWatch Logs を参照し、命名やマニフェストの修正を実施します。
+
+## 付録: よくあるエラー
+| 事象 | 対処 |
+| --- | --- |
+| `Facility code must be 9 digits` | 9 桁ゼロ埋めになっているか確認する。|
+| `Month must be in YYYYMM or YYYY-MM format` | `202504` か `2025-04` で指定する。|
+| `Target sequence already exists` | 同じ施設・月・ファイル種別で連番が重複していないか確認する。|
+| `Error: --records or --data-file must be provided.` | マニフェスト生成時に `--records` を入力するか対象ファイルを `--data-file` で指定する。|
+
+これらの手順を用いることで、docs/03_s3_naming.md の命名規約を満たした状態で手動アップロードを実施できます。

--- a/tools/generate_manifest.py
+++ b/tools/generate_manifest.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Utility to generate `_manifest.json` files for DPC raw uploads."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import pathlib
+import sys
+from typing import Optional
+
+FILE_TYPES = {"y1", "y3", "y4", "ef_in", "ef_out", "d", "h", "k"}
+HASH_ALGORITHMS = {"MD5": hashlib.md5, "SHA256": hashlib.sha256}
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a manifest JSON file that follows docs/03_s3_naming.md.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("target", type=pathlib.Path, help="Directory that will contain _manifest.json")
+    parser.add_argument("--facility", required=True, help="9 digit facility code")
+    parser.add_argument("--yyyymm", required=True, help="Month in YYYYMM format")
+    parser.add_argument("--file-type", required=True, choices=sorted(FILE_TYPES))
+    parser.add_argument("--records", type=int, help="Number of records in the uploaded file(s)")
+    parser.add_argument("--data-file", type=pathlib.Path, help="Source file used to compute hash/records")
+    parser.add_argument("--has-header", action="store_true", help="Treat the first line of --data-file as a header when counting records")
+    parser.add_argument("--hash-algorithm", choices=sorted(HASH_ALGORITHMS.keys()), default="SHA256")
+    parser.add_argument("--hash-value", help="Explicit hash value. Overrides --data-file hash computation")
+    parser.add_argument("--notes", help="Optional notes field")
+    parser.add_argument(
+        "--created-at",
+        help="ISO 8601 timestamp. Defaults to current local time",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting an existing _manifest.json",
+    )
+    return parser.parse_args(argv)
+
+
+def validate_facility(facility: str) -> None:
+    if len(facility) != 9 or not facility.isdigit():
+        raise ValueError("Facility code must be a 9 digit string.")
+
+
+def validate_month(yyyymm: str) -> None:
+    if len(yyyymm) != 6 or not yyyymm.isdigit():
+        raise ValueError("yyyymm must be a 6 digit string (YYYYMM).")
+    dt.datetime.strptime(yyyymm, "%Y%m")
+
+
+def detect_records(data_file: pathlib.Path, has_header: bool) -> int:
+    with data_file.open("r", encoding="utf-8") as fh:
+        count = sum(1 for _ in fh)
+    if has_header and count > 0:
+        count -= 1
+    return count
+
+
+def compute_hash(data_file: pathlib.Path, algorithm: str) -> str:
+    hash_func = HASH_ALGORITHMS[algorithm]()
+    with data_file.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            hash_func.update(chunk)
+    return hash_func.hexdigest()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        validate_facility(args.facility)
+        validate_month(args.yyyymm)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    target_dir: pathlib.Path = args.target
+    target_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = target_dir / "_manifest.json"
+
+    if manifest_path.exists() and not args.overwrite:
+        print(f"Error: {manifest_path} already exists. Use --overwrite to replace it.", file=sys.stderr)
+        return 1
+
+    records = args.records
+    if records is None:
+        if args.data_file is None:
+            print("Error: --records or --data-file must be provided.", file=sys.stderr)
+            return 1
+        if not args.data_file.exists():
+            print(f"Error: data file not found: {args.data_file}", file=sys.stderr)
+            return 1
+        records = detect_records(args.data_file, args.has_header)
+
+    if records < 0:
+        print("Error: records must be non-negative.", file=sys.stderr)
+        return 1
+
+    if args.hash_value:
+        hash_value = args.hash_value
+    else:
+        if args.data_file is None:
+            print("Error: provide --hash-value or --data-file to compute hash.", file=sys.stderr)
+            return 1
+        if not args.data_file.exists():
+            print(f"Error: data file not found: {args.data_file}", file=sys.stderr)
+            return 1
+        hash_value = compute_hash(args.data_file, args.hash_algorithm)
+
+    created_at = args.created_at
+    if created_at is None:
+        created_at = dt.datetime.now(dt.timezone.utc).astimezone().isoformat()
+
+    manifest = {
+        "yyyymm": args.yyyymm,
+        "file_type": args.file_type,
+        "facility_cd": args.facility,
+        "records": records,
+        "hash": {
+            "algorithm": args.hash_algorithm,
+            "value": hash_value,
+        },
+        "created_at": created_at,
+    }
+
+    if args.notes:
+        manifest["notes"] = args.notes
+
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"Manifest written to {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/prepare_upload.sh
+++ b/tools/prepare_upload.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: tools/prepare_upload.sh --facility <FACILITY_CD> --month <YYYY-MM|YYYYMM> --file-type <TYPE> --input <FILE> [options]
+
+Options:
+  --facility <FACILITY_CD>   9 digit facility code (e.g. 131000123)
+  --month <YYYY-MM|YYYYMM>   Target month. Hyphenated or compact form is accepted.
+  --file-type <TYPE>         One of: y1, y3, y4, ef_in, ef_out, d, h, k
+  --input <FILE>             Source file to be copied into the upload directory.
+  --dest <DIR>               Base directory for the upload tree. Defaults to ./upload_work/
+  --seq <NNN>                Sequence number (3 digits). Autodetected if omitted.
+  --move                     Move the file instead of copying it.
+  --dry-run                  Show the planned actions without copying/moving files.
+  --help                     Show this help.
+
+The script prepares an S3-compatible directory layout for manual uploads.
+It creates raw/yyyymm=<YYYY-MM>/<file_type>/ and renames the input file
+according to docs/03_s3_naming.md.
+USAGE
+}
+
+FACILITY=""
+MONTH=""
+FILE_TYPE=""
+INPUT_FILE=""
+DEST_DIR="./upload_work"
+SEQ=""
+MOVE="false"
+DRY_RUN="false"
+
+ALLOWED_TYPES=(y1 y3 y4 ef_in ef_out d h k)
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --facility)
+      FACILITY="$2"
+      shift 2
+      ;;
+    --month)
+      MONTH="$2"
+      shift 2
+      ;;
+    --file-type)
+      FILE_TYPE="$2"
+      shift 2
+      ;;
+    --input)
+      INPUT_FILE="$2"
+      shift 2
+      ;;
+    --dest)
+      DEST_DIR="$2"
+      shift 2
+      ;;
+    --seq)
+      SEQ="$2"
+      shift 2
+      ;;
+    --move)
+      MOVE="true"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$FACILITY" || -z "$MONTH" || -z "$FILE_TYPE" || -z "$INPUT_FILE" ]]; then
+  echo "Missing required arguments." >&2
+  show_help >&2
+  exit 1
+fi
+
+if [[ ! -f "$INPUT_FILE" ]]; then
+  echo "Input file not found: $INPUT_FILE" >&2
+  exit 1
+fi
+
+if [[ ! "$FACILITY" =~ ^[0-9]{9}$ ]]; then
+  echo "Facility code must be 9 digits." >&2
+  exit 1
+fi
+
+NORMALISED_MONTH=""
+if [[ "$MONTH" =~ ^[0-9]{6}$ ]]; then
+  NORMALISED_MONTH="${MONTH:0:4}-${MONTH:4:2}"
+elif [[ "$MONTH" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+  NORMALISED_MONTH="$MONTH"
+else
+  echo "Month must be in YYYYMM or YYYY-MM format." >&2
+  exit 1
+fi
+
+if [[ ! " ${ALLOWED_TYPES[*]} " =~ (^|[[:space:]])${FILE_TYPE}($|[[:space:]]) ]]; then
+  echo "Invalid file type: $FILE_TYPE" >&2
+  echo "Allowed values: ${ALLOWED_TYPES[*]}" >&2
+  exit 1
+fi
+
+EXTENSION="${INPUT_FILE##*.}"
+if [[ "$EXTENSION" == "$INPUT_FILE" ]]; then
+  EXTENSION="dat"
+fi
+
+DEST_FOLDER="$DEST_DIR/raw/yyyymm=$NORMALISED_MONTH/$FILE_TYPE"
+TARGET_NAME=""
+
+calculate_next_seq() {
+  local existing max_seq numeric
+  max_seq=0
+  if [[ -d "$DEST_FOLDER" ]]; then
+    shopt -s nullglob
+    for existing in "$DEST_FOLDER"/${FACILITY}_??????_${FILE_TYPE}_???.*; do
+      existing="${existing##*/}"
+      numeric="${existing%.*}"
+      numeric="${numeric##*_}"
+      if [[ "$numeric" =~ ^[0-9]{3}$ ]]; then
+        if ((10#$numeric > max_seq)); then
+          max_seq=$((10#$numeric))
+        fi
+      fi
+    done
+    shopt -u nullglob
+  fi
+  printf "%03d" $((max_seq + 1))
+}
+
+if [[ -z "$SEQ" ]]; then
+  mkdir -p "$DEST_FOLDER"
+  SEQ="$(calculate_next_seq)"
+else
+  if [[ ! "$SEQ" =~ ^[0-9]{3}$ ]]; then
+    echo "Sequence must be a 3 digit number (e.g. 001)." >&2
+    exit 1
+  fi
+  mkdir -p "$DEST_FOLDER"
+  TARGET_CHECK="$DEST_FOLDER/${FACILITY}_$(echo "$NORMALISED_MONTH" | tr -d -)_${FILE_TYPE}_${SEQ}."
+  if compgen -G "$TARGET_CHECK*" > /dev/null; then
+    echo "Target sequence already exists: ${SEQ}" >&2
+    exit 1
+  fi
+fi
+
+COMPACT_MONTH="$(echo "$NORMALISED_MONTH" | tr -d -)"
+TARGET_NAME="${FACILITY}_${COMPACT_MONTH}_${FILE_TYPE}_${SEQ}.${EXTENSION}"
+TARGET_PATH="$DEST_FOLDER/$TARGET_NAME"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[DRY-RUN] Would create directory: $DEST_FOLDER"
+  if [[ "$MOVE" == "true" ]]; then
+    echo "[DRY-RUN] Would move $INPUT_FILE -> $TARGET_PATH"
+  else
+    echo "[DRY-RUN] Would copy $INPUT_FILE -> $TARGET_PATH"
+  fi
+  exit 0
+fi
+
+mkdir -p "$DEST_FOLDER"
+
+if [[ "$MOVE" == "true" ]]; then
+  mv "$INPUT_FILE" "$TARGET_PATH"
+else
+  cp "$INPUT_FILE" "$TARGET_PATH"
+fi
+
+echo "Prepared file: $TARGET_PATH"
+
+MANIFEST_HINT="$DEST_FOLDER/_manifest.json"
+if [[ ! -f "$MANIFEST_HINT" ]]; then
+  cat <<EONOTE
+Next step: generate a manifest at $MANIFEST_HINT using tools/generate_manifest.py.
+EONOTE
+fi


### PR DESCRIPTION
## Summary
- add a bash helper that organises raw uploads into the expected S3 layout
- add a Python manifest generator and document the manual ingestion workflow

## Testing
- ./tools/prepare_upload.sh --help
- ./tools/generate_manifest.py --help

------
https://chatgpt.com/codex/tasks/task_e_68f8536c9b508329afa67b9345944266