### PR TITLE
feat: add terraform foundation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 # dpc_data_elt
 
-このリポジトリでは、OpenAI Codex を活用した開発プロセスを想定しています。具体的な運用ルールや手順は `AGENTS.md` を参照してください。
+DPC データ学習基盤の設計ドキュメントと IaC 定義を管理するリポジトリです。Terraform により AWS 上の最小構成を構築し、学習用 ELT パイプラ
+インの検証土台を提供します。
+
+## ディレクトリ構成
+
+- `docs/` – アーキテクチャ設計、運用方針などのドキュメント。
+- `plans/` – タスク別の実装計画。
+- `infra/terraform/` – 環境ごとの Terraform ルートモジュールと共通モジュール。
+- `tools/` – 開発補助スクリプト（必要に応じて追加）。
+
+## Terraform 初期化と運用ルール
+
+1. AWS CLI で認証情報 (`AdministratorAccess` 相当) を設定します。
+2. Terraform 実行環境で以下のコマンドを順に実行します。
+   ```bash
+   cd infra/terraform/dev
+   terraform init
+   terraform fmt
+   terraform validate
+   terraform plan
+   ```
+3. `dev` 環境は Terraform の `default` ワークスペースを利用します。他環境を作成する場合は `terraform workspace new <env>` を利用し、バッ
+   クエンドの `key` 規約（`<env>/terraform.tfstate`）に従ってください。
+4. リソースを適用する際は `terraform apply` を利用し、変更内容を確認してから承認します。
+
+> **補足**: S3 バックエンド (`dpc-learning-tfstate`) と DynamoDB ロックテーブル (`terraform-lock`) は初回のみ手動で作成するか、学習アカ
+> ウント側で既存のものを再利用してください。
+
+## 提供される AWS リソース
+
+タスク 01 の Terraform 定義により以下のリソースが作成されます。
+
+- KMS CMK (`alias/dpc-learning-kms`) および環境共通タグ。
+- データレイヤー用 S3 バケット (`dpc-learning-data-<env>`) のバージョニング・暗号化・パブリックアクセスブロック設定。
+- 管理イベントと S3 `raw/` データイベントを記録する AWS CloudTrail。
+- Secrets Manager におけるプレースホルダシークレット（Redshift 認証情報、Slack 通知）。
+- Lambda、Step Functions、Redshift COPY/UNLOAD 用の IAM ロールと最小権限ポリシー。
+
+Terraform の状態一覧は `terraform state list` で確認し、不要な手動変更が含まれていないか定期的にチェックしてください。

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -1,0 +1,31 @@
+locals {
+  base_tags = merge({
+    Project     = "dpc-learning",
+    Environment = var.environment
+  }, var.tags)
+}
+
+module "foundation" {
+  source = "../modules/foundation"
+
+  env  = var.environment
+  tags = local.base_tags
+}
+
+module "secrets" {
+  source = "../modules/secrets"
+
+  env         = var.environment
+  kms_key_arn = module.foundation.kms_key_arn
+  tags        = local.base_tags
+}
+
+module "iam" {
+  source = "../modules/iam"
+
+  env         = var.environment
+  bucket_arn  = module.foundation.data_bucket_arn
+  bucket_name = module.foundation.data_bucket_name
+  kms_key_arn = module.foundation.kms_key_arn
+  tags        = local.base_tags
+}

--- a/infra/terraform/dev/outputs.tf
+++ b/infra/terraform/dev/outputs.tf
@@ -1,0 +1,18 @@
+output "kms_key_arn" {
+  description = "ARN of the customer managed CMK used for platform encryption."
+  value       = module.foundation.kms_key_arn
+}
+
+output "data_bucket_name" {
+  description = "Name of the S3 bucket for DPC data layers."
+  value       = module.foundation.data_bucket_name
+}
+
+output "iam_role_arns" {
+  description = "Key IAM role ARNs provisioned for the learning platform."
+  value = {
+    lambda         = module.iam.role_lambda_arn
+    stepfunctions  = module.iam.role_stepfunctions_arn
+    redshift_copy  = module.iam.role_redshift_copy_arn
+  }
+}

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -1,0 +1,11 @@
+variable "environment" {
+  description = "Deployment environment identifier (e.g. dev, stg, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/dev/versions.tf
+++ b/infra/terraform/dev/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "dpc-learning-tfstate"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/infra/terraform/modules/foundation/main.tf
+++ b/infra/terraform/modules/foundation/main.tf
@@ -1,0 +1,148 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  bucket_name = "dpc-learning-data-${var.env}"
+  base_tags = merge(
+    {
+      Name = "dpc-learning-foundation-${var.env}"
+    },
+    var.tags
+  )
+}
+
+resource "aws_kms_key" "dpc" {
+  description             = "DPC learning platform CMK"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = merge(local.base_tags, {
+    Name = "alias/dpc-learning-kms"
+  })
+}
+
+resource "aws_kms_alias" "dpc" {
+  name          = "alias/dpc-learning-kms"
+  target_key_id = aws_kms_key.dpc.key_id
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket        = local.bucket_name
+  force_destroy = false
+
+  tags = merge(local.base_tags, {
+    Name = local.bucket_name
+  })
+}
+
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.dpc.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail" {
+  bucket = aws_s3_bucket.data.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AWSCloudTrailAclCheck"
+        Effect   = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.data.arn
+      },
+      {
+        Sid      = "AWSCloudTrailWrite"
+        Effect   = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.data.arn}/logs/cloudtrail/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudtrail" "dpc" {
+  name                          = "dpc-learning-${var.env}"
+  s3_bucket_name                = aws_s3_bucket.data.id
+  s3_key_prefix                 = "logs/cloudtrail"
+  kms_key_id                    = aws_kms_key.dpc.arn
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  enable_logging                = true
+  enable_log_file_validation    = true
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["${aws_s3_bucket.data.arn}/raw/"]
+    }
+  }
+
+  depends_on = [aws_s3_bucket_policy.cloudtrail]
+
+  tags = merge(local.base_tags, {
+    Name = "dpc-learning-${var.env}-cloudtrail"
+  })
+}

--- a/infra/terraform/modules/foundation/outputs.tf
+++ b/infra/terraform/modules/foundation/outputs.tf
@@ -1,0 +1,24 @@
+output "kms_key_arn" {
+  description = "ARN of the customer managed CMK."
+  value       = aws_kms_key.dpc.arn
+}
+
+output "kms_key_id" {
+  description = "Key ID of the customer managed CMK."
+  value       = aws_kms_key.dpc.key_id
+}
+
+output "data_bucket_name" {
+  description = "Name of the S3 bucket hosting DPC datasets."
+  value       = aws_s3_bucket.data.bucket
+}
+
+output "data_bucket_arn" {
+  description = "ARN of the S3 bucket hosting DPC datasets."
+  value       = aws_s3_bucket.data.arn
+}
+
+output "cloudtrail_arn" {
+  description = "ARN of the CloudTrail trail recording platform activity."
+  value       = aws_cloudtrail.dpc.arn
+}

--- a/infra/terraform/modules/foundation/variables.tf
+++ b/infra/terraform/modules/foundation/variables.tf
@@ -1,0 +1,10 @@
+variable "env" {
+  description = "Environment suffix used for resource naming."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to foundation resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,0 +1,223 @@
+data "aws_partition" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  logs_arn = "arn:${data.aws_partition.current.partition}:logs:*:${data.aws_caller_identity.current.account_id}:*"
+  bucket_objects_arn = "${var.bucket_arn}/*"
+}
+
+# Lambda execution role
+resource "aws_iam_role" "lambda" {
+  name = "role-lambda-dpc"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name = "role-lambda-dpc"
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_access" {
+  name = "role-lambda-dpc-access"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowLogging"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = local.logs_arn
+      },
+      {
+        Sid    = "AllowS3ReadWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ]
+        Resource = local.bucket_objects_arn
+      },
+      {
+        Sid    = "AllowListBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = var.bucket_arn
+      },
+      {
+        Sid    = "AllowKmsUsage"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey",
+          "kms:GenerateDataKeyWithoutPlaintext"
+        ]
+        Resource = var.kms_key_arn
+      },
+      {
+        Sid    = "AllowSecretsAccess"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:dpc/*"
+      },
+      {
+        Sid    = "AllowRedshiftDataApi"
+        Effect = "Allow"
+        Action = [
+          "redshift-data:CancelStatement",
+          "redshift-data:DescribeStatement",
+          "redshift-data:ExecuteStatement",
+          "redshift-data:GetStatementResult"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Step Functions role
+resource "aws_iam_role" "stepfunctions" {
+  name = "role-stepfunctions-dpc"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "states.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name = "role-stepfunctions-dpc"
+  })
+}
+
+resource "aws_iam_role_policy" "stepfunctions_access" {
+  name = "role-stepfunctions-dpc-access"
+  role = aws_iam_role.stepfunctions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowLambdaInvoke"
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowSnsPublish"
+        Effect = "Allow"
+        Action = [
+          "sns:Publish"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowEventBridge"
+        Effect = "Allow"
+        Action = [
+          "events:PutRule",
+          "events:PutTargets",
+          "events:DeleteRule",
+          "events:RemoveTargets",
+          "events:DescribeRule"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowLogDelivery"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogDelivery",
+          "logs:DeleteLogDelivery",
+          "logs:DescribeLogGroups",
+          "logs:GetLogDelivery",
+          "logs:ListLogDeliveries",
+          "logs:UpdateLogDelivery"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Redshift COPY/UNLOAD role
+resource "aws_iam_role" "redshift_copy" {
+  name = "role-redshift-copy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "redshift.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name = "role-redshift-copy"
+  })
+}
+
+resource "aws_iam_role_policy" "redshift_copy_access" {
+  name = "role-redshift-copy-access"
+  role = aws_iam_role.redshift_copy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3Read"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          var.bucket_arn,
+          local.bucket_objects_arn
+        ]
+      },
+      {
+        Sid    = "AllowKmsDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = var.kms_key_arn
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/iam/outputs.tf
+++ b/infra/terraform/modules/iam/outputs.tf
@@ -1,0 +1,14 @@
+output "role_lambda_arn" {
+  description = "Execution role ARN for Lambda functions."
+  value       = aws_iam_role.lambda.arn
+}
+
+output "role_stepfunctions_arn" {
+  description = "Execution role ARN for Step Functions state machines."
+  value       = aws_iam_role.stepfunctions.arn
+}
+
+output "role_redshift_copy_arn" {
+  description = "IAM role ARN assumed by Redshift for COPY/UNLOAD operations."
+  value       = aws_iam_role.redshift_copy.arn
+}

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -1,0 +1,25 @@
+variable "env" {
+  description = "Environment suffix used for logging and tagging."
+  type        = string
+}
+
+variable "bucket_arn" {
+  description = "ARN of the S3 bucket that stores platform data."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket that stores platform data."
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used for platform encryption."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to IAM resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/secrets/main.tf
+++ b/infra/terraform/modules/secrets/main.tf
@@ -1,0 +1,31 @@
+locals {
+  secrets = {
+    redshift_credentials = {
+      name        = "dpc/redshift/credentials"
+      description = "Redshift Data API credentials placeholder (${var.env})"
+    }
+    notifications_slack = {
+      name        = "dpc/notifications/slack"
+      description = "Slack webhook placeholder for DPC notifications (${var.env})"
+    }
+  }
+}
+
+resource "aws_secretsmanager_secret" "this" {
+  for_each = local.secrets
+
+  name        = each.value.name
+  description = each.value.description
+  kms_key_id  = var.kms_key_arn
+
+  tags = merge(var.tags, {
+    Name = each.value.name
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "placeholder" {
+  for_each = aws_secretsmanager_secret.this
+
+  secret_id     = each.value.id
+  secret_string = jsonencode({})
+}

--- a/infra/terraform/modules/secrets/outputs.tf
+++ b/infra/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,6 @@
+output "secret_arns" {
+  description = "ARNs of the Secrets Manager secrets."
+  value = {
+    for key, secret in aws_secretsmanager_secret.this : key => secret.arn
+  }
+}

--- a/infra/terraform/modules/secrets/variables.tf
+++ b/infra/terraform/modules/secrets/variables.tf
@@ -1,0 +1,15 @@
+variable "env" {
+  description = "Environment suffix for tagging consistency."
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt secrets."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to secrets resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add Terraform dev workspace configured with remote state backend and shared tags
- implement foundation module for KMS, S3 baseline and CloudTrail logging
- add secrets and IAM modules plus README instructions for initializing Terraform

## Testing
- terraform fmt -recursive *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f855d4857c8329bdd219509870967d