### PR TITLE
Add Redshift Serverless Terraform module and core DDL

### DIFF
--- a/ddl/core/mart_tables.sql
+++ b/ddl/core/mart_tables.sql
@@ -1,0 +1,80 @@
+-- Core mart schema tables for downstream analytics
+-- Source: docs/05_physical_ddl.md
+
+CREATE TABLE IF NOT EXISTS mart.fact_case_summary (
+    case_sk            BIGINT IDENTITY(1,1),
+    facility_cd        CHAR(9)   NOT NULL,
+    data_id            CHAR(10)  NOT NULL,
+    common_patient_id  VARCHAR(40),
+    admission_date     DATE,
+    discharge_date     DATE,
+    length_of_stay     INTEGER,
+    dpc_code           CHAR(14),
+    main_icd10         VARCHAR(10),
+    sex_code           CHAR(1),
+    age                SMALLINT,
+    surgery_flag       CHAR(1),
+    emergency_flag     CHAR(1),
+    outcome_code       CHAR(2),
+    total_points       INTEGER,
+    inclusive_points   INTEGER,
+    ffs_points         INTEGER,
+    noncovered_flag    BOOLEAN,
+    readmit_7d_flag    BOOLEAN,
+    readmit_30d_flag   BOOLEAN,
+    acuity_avg         DECIMAL(6,3),
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, data_id)
+ENCODE AUTO;
+ALTER TABLE mart.fact_case_summary
+    ADD PRIMARY KEY (facility_cd, data_id) NOT ENFORCED;
+ALTER TABLE mart.fact_case_summary
+    ADD FOREIGN KEY (facility_cd) REFERENCES ref.dim_facility(facility_cd) NOT ENFORCED;
+ALTER TABLE mart.fact_case_summary
+    ADD FOREIGN KEY (dpc_code) REFERENCES ref.dim_dpc_code(dpc_code) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS mart.fact_cost_monthly (
+    facility_cd        CHAR(9)   NOT NULL,
+    year_month         CHAR(6)   NOT NULL,
+    inpatient_points   INTEGER,
+    outpatient_points  INTEGER,
+    inclusive_points   INTEGER,
+    drug_points        INTEGER,
+    material_points    INTEGER,
+    surgery_points     INTEGER,
+    other_points       INTEGER,
+    total_points       INTEGER,
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, year_month)
+ENCODE AUTO;
+ALTER TABLE mart.fact_cost_monthly
+    ADD PRIMARY KEY (facility_cd, year_month) NOT ENFORCED;
+ALTER TABLE mart.fact_cost_monthly
+    ADD FOREIGN KEY (facility_cd) REFERENCES ref.dim_facility(facility_cd) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS mart.fact_dx_outcome (
+    facility_cd        CHAR(9)   NOT NULL,
+    year_month         CHAR(6)   NOT NULL,
+    dpc_code           CHAR(14)  NOT NULL,
+    cases              INTEGER,
+    avg_los            DECIMAL(6,2),
+    mortality_rate     DECIMAL(5,2),
+    readmit_30d_rate   DECIMAL(5,2),
+    avg_acuity         DECIMAL(6,3),
+    surgery_ratio      DECIMAL(5,2),
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, dpc_code)
+ENCODE AUTO;
+ALTER TABLE mart.fact_dx_outcome
+    ADD PRIMARY KEY (facility_cd, year_month, dpc_code) NOT ENFORCED;
+ALTER TABLE mart.fact_dx_outcome
+    ADD FOREIGN KEY (facility_cd) REFERENCES ref.dim_facility(facility_cd) NOT ENFORCED;
+ALTER TABLE mart.fact_dx_outcome
+    ADD FOREIGN KEY (dpc_code) REFERENCES ref.dim_dpc_code(dpc_code) NOT ENFORCED;

--- a/ddl/core/raw_tables.sql
+++ b/ddl/core/raw_tables.sql
@@ -1,0 +1,109 @@
+-- Core raw schema tables required for COPY operations
+-- Source: docs/05_physical_ddl.md
+
+CREATE TABLE IF NOT EXISTS raw.y1_inpatient (
+    facility_cd       CHAR(9)   NOT NULL,
+    data_id           CHAR(10)  NOT NULL,
+    admission_date    DATE,
+    discharge_date    DATE,
+    sex_code          CHAR(1),
+    birth_date        DATE,
+    age               SMALLINT,
+    dpc_code          CHAR(14),
+    main_icd10        VARCHAR(10),
+    outcome_code      CHAR(2),
+    emergency_flag    CHAR(1),
+    surgery_flag      CHAR(1),
+    height_cm         DECIMAL(5,2),
+    weight_kg         DECIMAL(5,2),
+    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, data_id)
+ENCODE AUTO;
+ALTER TABLE raw.y1_inpatient
+    ADD PRIMARY KEY (facility_cd, data_id) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS raw.y3_facility (
+    facility_cd       CHAR(9)  NOT NULL,
+    report_year       CHAR(4)  NOT NULL,
+    facility_name     VARCHAR(120),
+    bed_function_code CHAR(2),
+    hospital_group    VARCHAR(40),
+    pref_code         CHAR(2),
+    city_code         CHAR(5),
+    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTSTYLE ALL
+SORTKEY(facility_cd)
+ENCODE AUTO;
+ALTER TABLE raw.y3_facility
+    ADD PRIMARY KEY (facility_cd, report_year) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS raw.ef_inpatient (
+    facility_cd       CHAR(9)  NOT NULL,
+    data_id           CHAR(10) NOT NULL,
+    seq_no            INTEGER  NOT NULL,
+    detail_no         INTEGER  NOT NULL,
+    service_date      DATE,
+    service_code      VARCHAR(12),
+    unit_code         VARCHAR(3),
+    qty               DECIMAL(10,3),
+    points            INTEGER,
+    yen_flag          CHAR(1),
+    doctor_code       VARCHAR(10),
+    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, data_id, seq_no)
+ENCODE AUTO;
+ALTER TABLE raw.ef_inpatient
+    ADD PRIMARY KEY (facility_cd, data_id, seq_no, detail_no) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS raw.d_inclusive (
+    facility_cd        CHAR(9)  NOT NULL,
+    data_id            CHAR(10) NOT NULL,
+    segment_no         SMALLINT NOT NULL,
+    dpc_code           CHAR(14),
+    start_date         DATE,
+    end_date           DATE,
+    inclusive_points   INTEGER,
+    adjust_points      INTEGER,
+    reason_code        CHAR(2),
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, data_id)
+ENCODE AUTO;
+ALTER TABLE raw.d_inclusive
+    ADD PRIMARY KEY (facility_cd, data_id, segment_no) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS raw.h_daily (
+    facility_cd     CHAR(9)  NOT NULL,
+    data_id         CHAR(10) NOT NULL,
+    eval_date       DATE     NOT NULL,
+    seq_no          SMALLINT NOT NULL,
+    item_code       VARCHAR(6),
+    severity_score  SMALLINT,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, data_id, eval_date)
+ENCODE AUTO;
+ALTER TABLE raw.h_daily
+    ADD PRIMARY KEY (facility_cd, data_id, eval_date, seq_no) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS raw.k_common_id (
+    facility_cd       CHAR(9)  NOT NULL,
+    data_id           CHAR(10) NOT NULL,
+    common_patient_id VARCHAR(40) NOT NULL,
+    birth_month       DATE,
+    insurer_no        VARCHAR(8),
+    subscriber_no     VARCHAR(8),
+    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTKEY(facility_cd)
+SORTKEY(facility_cd, data_id)
+ENCODE AUTO;
+ALTER TABLE raw.k_common_id
+    ADD PRIMARY KEY (facility_cd, data_id) NOT ENFORCED;

--- a/ddl/core/ref_tables.sql
+++ b/ddl/core/ref_tables.sql
@@ -1,0 +1,57 @@
+-- Core reference schema tables required by mart fact tables
+-- Source: docs/05_physical_ddl.md
+
+CREATE TABLE IF NOT EXISTS ref.dim_facility (
+    facility_cd        CHAR(9)  NOT NULL,
+    facility_name      VARCHAR(120),
+    facility_name_kana VARCHAR(180),
+    bed_function_code  CHAR(2),
+    hospital_group     VARCHAR(40),
+    pref_code          CHAR(2),
+    medical_region     VARCHAR(10),
+    dpc_category       VARCHAR(20),
+    coefficient_i      DECIMAL(6,4),
+    coefficient_ii     DECIMAL(6,4),
+    is_dpc_hospital    BOOLEAN,
+    effective_from     DATE,
+    effective_to       DATE,
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTSTYLE ALL
+SORTKEY(facility_cd)
+ENCODE AUTO;
+ALTER TABLE ref.dim_facility
+    ADD PRIMARY KEY (facility_cd, effective_from) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS ref.dim_dpc_code (
+    dpc_code           CHAR(14) NOT NULL,
+    mdc_code           CHAR(2),
+    mdc_name           VARCHAR(80),
+    diagnosis_name     VARCHAR(160),
+    surgery_category   VARCHAR(80),
+    resource_level     VARCHAR(40),
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTSTYLE ALL
+SORTKEY(dpc_code)
+ENCODE AUTO;
+ALTER TABLE ref.dim_dpc_code
+    ADD PRIMARY KEY (dpc_code) NOT ENFORCED;
+
+CREATE TABLE IF NOT EXISTS ref.dim_date (
+    date_key           DATE NOT NULL,
+    year               SMALLINT,
+    quarter            SMALLINT,
+    month              SMALLINT,
+    day                SMALLINT,
+    year_month         CHAR(6),
+    week               SMALLINT,
+    weekday            SMALLINT,
+    is_holiday         BOOLEAN,
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+DISTSTYLE ALL
+SORTKEY(date_key)
+ENCODE AUTO;
+ALTER TABLE ref.dim_date
+    ADD PRIMARY KEY (date_key) NOT ENFORCED;

--- a/scripts/bootstrap_redshift.sql
+++ b/scripts/bootstrap_redshift.sql
@@ -1,0 +1,8 @@
+-- Bootstrap script for initializing Redshift Serverless schemas
+-- Execute via Redshift Data API or any SQL client after the namespace is provisioned.
+
+create schema if not exists raw;
+create schema if not exists stage;
+create schema if not exists mart;
+create schema if not exists ref;
+create schema if not exists dq;

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_iam_role" "redshift_copy" {
+  name = var.copy_role_name
+}
+
+data "aws_kms_alias" "this" {
+  name = var.kms_alias_name
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_subnet" "selected" {
+  for_each = toset(data.aws_subnets.default.ids)
+  id       = each.key
+}
+
+locals {
+  public_subnet_ids = [
+    for subnet in data.aws_subnet.selected : subnet.id
+    if subnet.map_public_ip_on_launch
+  ]
+}
+
+resource "aws_security_group" "redshift_serverless" {
+  name        = "${var.workgroup_name}-sg"
+  description = "Redshift Serverless restricted ingress"
+  vpc_id      = data.aws_vpc.default.id
+
+  revoke_rules_on_delete = true
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.workgroup_name}-sg"
+  })
+}
+
+module "redshift" {
+  source = "./modules/redshift"
+
+  workgroup_name             = var.workgroup_name
+  namespace_name             = var.namespace_name
+  database_name              = var.database_name
+  base_capacity              = var.base_capacity
+  snapshot_retention_period  = var.snapshot_retention_period
+  subnet_ids                 = local.public_subnet_ids
+  security_group_ids         = [aws_security_group.redshift_serverless.id]
+  copy_role_arn              = data.aws_iam_role.redshift_copy.arn
+  kms_key_arn                = data.aws_kms_alias.this.target_key_arn
+  log_exports                = var.log_exports
+  manage_admin_password      = var.manage_admin_password
+  namespace_tags             = var.namespace_tags
+  workgroup_tags             = var.workgroup_tags
+}
+
+output "redshift_namespace" {
+  description = "Details of the Redshift Serverless namespace."
+  value = {
+    name     = module.redshift.namespace_name
+    arn      = module.redshift.namespace_arn
+    admin_db = var.database_name
+  }
+}
+
+output "redshift_workgroup" {
+  description = "Details of the Redshift Serverless workgroup."
+  value = {
+    name     = module.redshift.workgroup_name
+    id       = module.redshift.workgroup_id
+    endpoint = module.redshift.workgroup_endpoint
+  }
+}

--- a/terraform/modules/redshift/main.tf
+++ b/terraform/modules/redshift/main.tf
@@ -1,0 +1,25 @@
+resource "aws_redshiftserverless_namespace" "this" {
+  namespace_name            = var.namespace_name
+  db_name                   = var.database_name
+  default_iam_role_arn      = var.copy_role_arn
+  iam_roles                 = [var.copy_role_arn]
+  kms_key_id                = var.kms_key_arn
+  log_exports               = var.log_exports
+  manage_admin_password     = var.manage_admin_password
+  snapshot_retention_period = var.snapshot_retention_period
+
+  tags = merge(var.tags, var.namespace_tags)
+}
+
+resource "aws_redshiftserverless_workgroup" "this" {
+  depends_on = [aws_redshiftserverless_namespace.this]
+
+  workgroup_name        = var.workgroup_name
+  namespace_name        = aws_redshiftserverless_namespace.this.namespace_name
+  base_capacity         = var.base_capacity
+  security_group_ids    = var.security_group_ids
+  subnet_ids            = var.subnet_ids
+  enhanced_vpc_routing  = true
+
+  tags = merge(var.tags, var.workgroup_tags)
+}

--- a/terraform/modules/redshift/outputs.tf
+++ b/terraform/modules/redshift/outputs.tf
@@ -1,0 +1,27 @@
+output "namespace_name" {
+  description = "The name of the Redshift Serverless namespace."
+  value       = aws_redshiftserverless_namespace.this.namespace_name
+}
+
+output "namespace_arn" {
+  description = "The ARN of the Redshift Serverless namespace."
+  value       = aws_redshiftserverless_namespace.this.arn
+}
+
+output "workgroup_name" {
+  description = "The name of the Redshift Serverless workgroup."
+  value       = aws_redshiftserverless_workgroup.this.workgroup_name
+}
+
+output "workgroup_id" {
+  description = "The unique identifier of the workgroup."
+  value       = aws_redshiftserverless_workgroup.this.id
+}
+
+output "workgroup_endpoint" {
+  description = "Endpoint information for connecting via JDBC/ODBC."
+  value = {
+    address = aws_redshiftserverless_workgroup.this.endpoint[0].address
+    port    = aws_redshiftserverless_workgroup.this.endpoint[0].port
+  }
+}

--- a/terraform/modules/redshift/variables.tf
+++ b/terraform/modules/redshift/variables.tf
@@ -1,0 +1,72 @@
+variable "workgroup_name" {
+  description = "Name of the Redshift Serverless workgroup."
+  type        = string
+}
+
+variable "namespace_name" {
+  description = "Name of the Redshift Serverless namespace."
+  type        = string
+}
+
+variable "database_name" {
+  description = "Default database name to create in the namespace."
+  type        = string
+}
+
+variable "base_capacity" {
+  description = "Compute capacity for the workgroup (in RPUs)."
+  type        = number
+}
+
+variable "snapshot_retention_period" {
+  description = "Number of days to retain automatic snapshots."
+  type        = number
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for the Redshift workgroup."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs attached to the workgroup."
+  type        = list(string)
+}
+
+variable "copy_role_arn" {
+  description = "IAM role ARN with COPY/UNLOAD permissions."
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN used to encrypt the namespace."
+  type        = string
+}
+
+variable "log_exports" {
+  description = "Log exports enabled on the namespace."
+  type        = list(string)
+}
+
+variable "manage_admin_password" {
+  description = "Whether to allow Redshift to manage the admin password."
+  type        = bool
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "namespace_tags" {
+  description = "Additional tags for the namespace resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "workgroup_tags" {
+  description = "Additional tags for the workgroup resource."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,80 @@
+variable "aws_region" {
+  description = "AWS region where resources will be created."
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "copy_role_name" {
+  description = "Name of the IAM role that Redshift uses for COPY and UNLOAD operations."
+  type        = string
+  default     = "role-redshift-copy"
+}
+
+variable "kms_alias_name" {
+  description = "KMS key alias used to encrypt the Redshift Serverless namespace."
+  type        = string
+  default     = "alias/dpc-learning-kms"
+}
+
+variable "workgroup_name" {
+  description = "Name of the Redshift Serverless workgroup."
+  type        = string
+  default     = "dpc-learning-wg"
+}
+
+variable "namespace_name" {
+  description = "Name of the Redshift Serverless namespace."
+  type        = string
+  default     = "dpc-learning-ns"
+}
+
+variable "database_name" {
+  description = "Default database name for the namespace."
+  type        = string
+  default     = "dpc_learning"
+}
+
+variable "base_capacity" {
+  description = "Base capacity (RPU) for the Redshift Serverless workgroup."
+  type        = number
+  default     = 8
+}
+
+variable "snapshot_retention_period" {
+  description = "Automatic snapshot retention period in days."
+  type        = number
+  default     = 7
+}
+
+variable "log_exports" {
+  description = "List of log exports to enable for the namespace."
+  type        = list(string)
+  default     = ["userlog", "connectionlog", "useractivitylog"]
+}
+
+variable "manage_admin_password" {
+  description = "Whether Redshift should manage the admin password for the namespace."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Common tags applied to shared resources."
+  type        = map(string)
+  default = {
+    Project = "dpc-learning"
+    Stack   = "minimal"
+  }
+}
+
+variable "namespace_tags" {
+  description = "Additional tags for the namespace resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "workgroup_tags" {
+  description = "Additional tags for the workgroup resource."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add a Terraform root configuration and reusable Redshift Serverless module for the minimal environment
- provision security group and wiring for the default VPC along with outputs for namespace and workgroup connection details
- include schema bootstrap SQL and core raw/mart/ref DDL scripts to initialize the warehouse structures

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f855f43dd88329b674509c9e604c74