### PR TITLE
Add Terraform pipeline module for minimal ELT orchestration

### DIFF
--- a/modules/pipeline/README.md
+++ b/modules/pipeline/README.md
@@ -1,0 +1,125 @@
+# Pipeline Module
+
+This Terraform module provisions the minimal ELT orchestration plane described in
+[`plans/minimal_task_03_pipeline.md`](../../plans/minimal_task_03_pipeline.md).
+It wires together Step Functions, Lambda, ECS on Fargate, EventBridge, and SNS
+so the nightly load documented in `docs/07_elt_pipeline.md` can be exercised in a
+learning environment.
+
+## Components
+
+The module creates the following building blocks:
+
+- Five Lambda functions (`dpc-validate-manifest`, `dpc-copy-raw`,
+  `dpc-compute-readmit`, `dpc-export-parquet`, `dpc-notify`) that share a common
+  execution role and optional Lambda layers.
+- An SNS topic with a Lambda subscription so notifications emitted by
+  `dpc-notify` can be fanned out to other channels (for example Slack via
+  Secrets Manager).
+- An ECR repository plus an ECS task definition used to execute dbt commands on
+  AWS Fargate with Redshift credentials supplied from Secrets Manager.
+- An AWS Step Functions state machine that mirrors the `Validate → Copy →
+  Compute → dbt → Export → Notify` flow, including a `RollbackStage` `Pass`
+  state that surfaces potential TRUNCATE statements through Terraform variables.
+- An EventBridge rule/target pair that kicks off the state machine on a schedule
+  and an IAM policy that allows operators to start the flow manually.
+
+## Usage
+
+````hcl
+module "pipeline" {
+  source = "./modules/pipeline"
+
+  tags                   = { project = "dpc-learning" }
+  lambda_package_bucket  = var.lambda_package_bucket
+  lambda_role_arn        = aws_iam_role.lambda.arn
+  lambda_layers          = [aws_lambda_layer_version.common.arn]
+  notify_slack_secret_arn = aws_secretsmanager_secret.slack.arn
+  redshift_secret_arn     = aws_secretsmanager_secret.redshift.arn
+  export_parquet_target_bucket = aws_s3_bucket.processed.bucket
+
+  lambda_functions = {
+    validate_manifest = {
+      handler     = "app.handler"
+      runtime     = "python3.11"
+      package_key = "lambda/dpc-validate-manifest.zip"
+    }
+    copy_raw = {
+      handler     = "app.handler"
+      runtime     = "python3.11"
+      package_key = "lambda/dpc-copy-raw.zip"
+    }
+    compute_readmit = {
+      handler     = "app.handler"
+      runtime     = "python3.11"
+      package_key = "lambda/dpc-compute-readmit.zip"
+    }
+    export_parquet = {
+      handler     = "app.handler"
+      runtime     = "python3.11"
+      package_key = "lambda/dpc-export-parquet.zip"
+    }
+    notify = {
+      handler     = "app.handler"
+      runtime     = "python3.11"
+      package_key = "lambda/dpc-notify.zip"
+    }
+  }
+
+  sns_topic_name                = "dpc-pipeline-notifications"
+  state_machine_name            = "dpc-elt-pipeline"
+  state_machine_role_arn        = aws_iam_role.step_functions.arn
+  eventbridge_schedule_expression = "cron(0 2 * * ? *)"
+  eventbridge_role_arn            = aws_iam_role.events_to_sfn.arn
+
+  ecs_cluster_arn        = aws_ecs_cluster.main.arn
+  ecs_subnet_ids         = module.network.private_subnet_ids
+  ecs_security_group_ids = [aws_security_group.ecs.id]
+  dbt_execution_role_arn = aws_iam_role.ecs_execution.arn
+  dbt_task_role_arn      = aws_iam_role.ecs_task.arn
+}
+````
+
+Only the Lambda handler, runtime, and deployment package S3 keys are required
+for each function. Optional inputs allow you to override memory, timeout,
+command/arguments for dbt, additional environment variables, or the Step
+Functions notification payload.
+
+### Step Functions definition
+
+The generated state machine uses `arn:aws:states:::lambda:invoke` for Lambda
+steps and `arn:aws:states:::ecs:runTask.sync` for the dbt stage. Failures in the
+`CopyRaw`, `ComputeReadmit`, and ECS stages transition to `RollbackStage`, which
+is expressed as a `Pass` state that only records whether TRUNCATE statements
+should run before the next attempt. The value is controlled by
+`var.enable_rollback_truncate` and `var.rollback_statements` so destructive
+changes remain opt-in in the training environment.
+
+### Notifications
+
+By default the same `dpc-notify` function is invoked directly from Step
+Functions and can also be triggered by SNS publications. The module injects the
+Slack webhook secret ARN automatically when `var.notify_slack_secret_arn` is
+set, allowing the Lambda implementation to fetch credentials from Secrets
+Manager and call incoming webhooks.
+
+### dbt execution
+
+The ECS task definition produces a single-container Fargate task. Environment
+variables defined through `var.dbt_environment_defaults` and
+`var.dbt_environment_overrides` are baked into the task definition, while
+`var.dbt_state_machine_environment` can push runtime values (static strings or
+state paths) through Step Functions overrides.
+
+### Outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `lambda_function_arns` | Map of Lambda function ARNs keyed by logical name. |
+| `sns_topic_arn` | Notification topic ARN for pipeline alerts. |
+| `sns_subscription_arn` | ARN of the Lambda subscription attached to the topic. |
+| `dbt_repository_url` | ECR repository URL for the dbt runner image. |
+| `dbt_task_definition_arn` | ECS task definition ARN for Fargate executions. |
+| `state_machine_arn` | Step Functions state machine ARN. |
+| `event_rule_arn` | EventBridge rule ARN for scheduled executions. |
+| `manual_start_policy_arn` | IAM policy ARN that grants manual start privileges. |

--- a/modules/pipeline/main.tf
+++ b/modules/pipeline/main.tf
@@ -1,0 +1,334 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+locals {
+  lambda_functions = {
+    for name, cfg in var.lambda_functions : name => {
+      function_name = try(trimspace(cfg.function_name), "") != "" ? cfg.function_name : "dpc-${replace(name, "_", "-")}"
+      description   = try(trimspace(cfg.description), "") != "" ? cfg.description : "DPC pipeline ${replace(name, "_", " ")} function"
+      handler       = cfg.handler
+      runtime       = cfg.runtime
+      package_key   = cfg.package_key
+      source_code_hash = try(cfg.source_code_hash, null)
+      timeout       = try(cfg.timeout, null) != null ? cfg.timeout : var.lambda_default_timeout
+      memory_size   = try(cfg.memory_size, null) != null ? cfg.memory_size : var.lambda_default_memory_size
+      environment   = merge(
+        var.lambda_environment_defaults,
+        try(cfg.environment, {}),
+        name == "notify" && var.notify_slack_secret_arn != "" ? { SLACK_WEBHOOK_SECRET_ARN = var.notify_slack_secret_arn } : {},
+        name == "compute_readmit" && var.redshift_secret_arn != "" ? { REDSHIFT_SECRET_ARN = var.redshift_secret_arn } : {},
+        name == "export_parquet" && var.export_parquet_target_bucket != "" ? { TARGET_BUCKET = var.export_parquet_target_bucket } : {}
+      )
+    }
+  }
+
+  dbt_environment_base = merge(
+    var.dbt_environment_defaults,
+    var.redshift_secret_arn != "" ? { REDSHIFT_SECRET_ARN = var.redshift_secret_arn } : {},
+    var.dbt_environment_overrides
+  )
+
+  dbt_environment_pairs = [
+    for k, v in local.dbt_environment_base : {
+      Name  = k
+      Value = v
+    }
+  ]
+
+  dbt_container_definition = merge({
+    name      = var.dbt_container_name
+    image     = var.dbt_container_image != "" ? var.dbt_container_image : "${aws_ecr_repository.dbt.repository_url}:latest"
+    essential = true
+    command   = var.dbt_container_command
+    environment = [
+      for k, v in local.dbt_environment_base : {
+        name  = k
+        value = v
+      }
+    ]
+  }, var.dbt_log_configuration != null ? { logConfiguration = var.dbt_log_configuration } : {})
+
+  dbt_state_machine_environment_overrides = [
+    for item in var.dbt_state_machine_environment :
+    merge(
+      { Name = item.name },
+      try(item.value, null) != null ? { Value = item.value } : {},
+      try(item.value_path, null) != null ? { "Value.$" = item.value_path } : {}
+    )
+  ]
+}
+
+resource "aws_lambda_function" "pipeline" {
+  for_each = local.lambda_functions
+
+  function_name = each.value.function_name
+  role          = var.lambda_role_arn
+  description   = each.value.description
+  handler       = each.value.handler
+  runtime       = each.value.runtime
+  s3_bucket     = var.lambda_package_bucket
+  s3_key        = each.value.package_key
+  timeout       = each.value.timeout
+  memory_size   = each.value.memory_size
+  publish       = var.lambda_publish
+  tags          = var.tags
+
+  environment {
+    variables = each.value.environment
+  }
+
+  layers         = var.lambda_layers
+  source_code_hash = try(each.value.source_code_hash, null)
+
+}
+
+resource "aws_sns_topic" "pipeline" {
+  name = var.sns_topic_name
+  tags = var.tags
+}
+
+resource "aws_lambda_permission" "allow_sns_notify" {
+  statement_id  = "AllowExecutionFromSnsNotify"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.pipeline["notify"].function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.pipeline.arn
+}
+
+resource "aws_sns_topic_subscription" "notify" {
+  topic_arn = aws_sns_topic.pipeline.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.pipeline["notify"].arn
+
+  raw_message_delivery = var.sns_subscription_raw_message_delivery
+
+  depends_on = [aws_lambda_permission.allow_sns_notify]
+}
+
+resource "aws_ecr_repository" "dbt" {
+  name                 = var.dbt_repository_name
+  force_delete         = var.dbt_repository_force_delete
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_task_definition" "dbt" {
+  family                   = var.dbt_task_family
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = tostring(var.dbt_task_cpu)
+  memory                   = tostring(var.dbt_task_memory)
+  execution_role_arn       = var.dbt_execution_role_arn
+  task_role_arn            = var.dbt_task_role_arn
+  container_definitions    = jsonencode([local.dbt_container_definition])
+  tags                     = var.tags
+}
+
+locals {
+  lambda_arns = { for name, fn in aws_lambda_function.pipeline : name => fn.arn }
+
+  dbt_container_override_environment = concat(
+    local.dbt_environment_pairs,
+    local.dbt_state_machine_environment_overrides
+  )
+
+  state_machine_definition = jsonencode({
+    Comment = var.state_machine_comment
+    StartAt = "ValidateManifest"
+    States = {
+      ValidateManifest = {
+        Type       = "Task"
+        Resource   = "arn:aws:states:::lambda:invoke"
+        ResultPath = "$.validate_manifest"
+        Parameters = {
+          FunctionName = local.lambda_arns.validate_manifest
+          "Payload.$"  = "$"
+        }
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            ResultPath  = "$.error"
+            Next        = "NotifyFailure"
+          }
+        ]
+        Next = "CopyRaw"
+      }
+
+      CopyRaw = {
+        Type       = "Task"
+        Resource   = "arn:aws:states:::lambda:invoke"
+        ResultPath = "$.copy_raw"
+        Parameters = {
+          FunctionName = local.lambda_arns.copy_raw
+          "Payload.$"  = "$"
+        }
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            ResultPath  = "$.error"
+            Next        = "RollbackStage"
+          }
+        ]
+        Next = "ComputeReadmit"
+      }
+
+      ComputeReadmit = {
+        Type       = "Task"
+        Resource   = "arn:aws:states:::lambda:invoke"
+        ResultPath = "$.compute_readmit"
+        Parameters = {
+          FunctionName = local.lambda_arns.compute_readmit
+          "Payload.$"  = "$"
+        }
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            ResultPath  = "$.error"
+            Next        = "RollbackStage"
+          }
+        ]
+        Next = "RunDbtTransformations"
+      }
+
+      RunDbtTransformations = {
+        Type       = "Task"
+        Resource   = "arn:aws:states:::ecs:runTask.sync"
+        ResultPath = "$.dbt"
+        Parameters = {
+          LaunchType     = "FARGATE"
+          Cluster        = var.ecs_cluster_arn
+          TaskDefinition = aws_ecs_task_definition.dbt.arn
+          NetworkConfiguration = {
+            AwsvpcConfiguration = {
+              Subnets        = var.ecs_subnet_ids
+              SecurityGroups = var.ecs_security_group_ids
+              AssignPublicIp = var.ecs_assign_public_ip ? "ENABLED" : "DISABLED"
+            }
+          }
+          Overrides = {
+            ContainerOverrides = [
+              {
+                Name      = var.dbt_container_name
+                Command   = var.dbt_state_machine_command
+                Environment = local.dbt_container_override_environment
+              }
+            ]
+          }
+        }
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            ResultPath  = "$.error"
+            Next        = "RollbackStage"
+          }
+        ]
+        Next = "ExportParquet"
+      }
+
+      ExportParquet = {
+        Type       = "Task"
+        Resource   = "arn:aws:states:::lambda:invoke"
+        ResultPath = "$.export_parquet"
+        Parameters = {
+          FunctionName = local.lambda_arns.export_parquet
+          "Payload.$"  = "$"
+        }
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            ResultPath  = "$.error"
+            Next        = "NotifyFailure"
+          }
+        ]
+        Next = "NotifySuccess"
+      }
+
+      RollbackStage = {
+        Type       = "Pass"
+        ResultPath = "$.rollback"
+        Result = {
+          truncate_enabled = var.enable_rollback_truncate
+          statements       = var.rollback_statements
+        }
+        Next = "NotifyFailure"
+      }
+
+      NotifySuccess = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          FunctionName = local.lambda_arns.notify
+          Payload = {
+            status   = "SUCCESS"
+            "detail.$" = "$"
+          }
+        }
+        End = true
+      }
+
+      NotifyFailure = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          FunctionName = local.lambda_arns.notify
+          Payload = {
+            status   = "FAILURE"
+            "detail.$" = "$"
+          }
+        }
+        End = true
+      }
+    }
+  })
+}
+
+resource "aws_sfn_state_machine" "pipeline" {
+  name       = var.state_machine_name
+  role_arn   = var.state_machine_role_arn
+  definition = local.state_machine_definition
+  tags       = var.tags
+}
+
+resource "aws_cloudwatch_event_rule" "pipeline" {
+  name                = "${var.state_machine_name}-schedule"
+  schedule_expression = var.eventbridge_schedule_expression
+  tags                = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "pipeline" {
+  rule      = aws_cloudwatch_event_rule.pipeline.name
+  target_id = "${var.state_machine_name}-trigger"
+  arn       = aws_sfn_state_machine.pipeline.arn
+  role_arn  = var.eventbridge_role_arn
+  input     = jsonencode(var.eventbridge_input)
+}
+
+resource "aws_iam_policy" "manual_start" {
+  name        = var.manual_start_policy_name
+  description = "Allows operators to manually start and inspect the DPC pipeline state machine."
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "states:DescribeStateMachine",
+          "states:ListExecutions",
+          "states:StartExecution"
+        ]
+        Resource = aws_sfn_state_machine.pipeline.arn
+      }
+    ]
+  })
+}

--- a/modules/pipeline/outputs.tf
+++ b/modules/pipeline/outputs.tf
@@ -1,0 +1,39 @@
+output "lambda_function_arns" {
+  description = "Map of Lambda function ARNs keyed by their logical name."
+  value       = { for name, fn in aws_lambda_function.pipeline : name => fn.arn }
+}
+
+output "sns_topic_arn" {
+  description = "ARN of the SNS topic used for pipeline notifications."
+  value       = aws_sns_topic.pipeline.arn
+}
+
+output "sns_subscription_arn" {
+  description = "ARN of the Lambda subscription attached to the notification topic."
+  value       = aws_sns_topic_subscription.notify.arn
+}
+
+output "dbt_repository_url" {
+  description = "URL of the ECR repository that stores the dbt runner image."
+  value       = aws_ecr_repository.dbt.repository_url
+}
+
+output "dbt_task_definition_arn" {
+  description = "ARN of the ECS task definition that executes dbt commands."
+  value       = aws_ecs_task_definition.dbt.arn
+}
+
+output "state_machine_arn" {
+  description = "ARN of the Step Functions state machine orchestrating the ELT pipeline."
+  value       = aws_sfn_state_machine.pipeline.arn
+}
+
+output "event_rule_arn" {
+  description = "ARN of the EventBridge rule that schedules the pipeline execution."
+  value       = aws_cloudwatch_event_rule.pipeline.arn
+}
+
+output "manual_start_policy_arn" {
+  description = "ARN of the IAM policy that enables manual pipeline execution."
+  value       = aws_iam_policy.manual_start.arn
+}

--- a/modules/pipeline/variables.tf
+++ b/modules/pipeline/variables.tf
@@ -1,0 +1,283 @@
+variable "tags" {
+  description = "Common tags applied to all taggable resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "lambda_package_bucket" {
+  description = "S3 bucket that stores Lambda deployment packages."
+  type        = string
+}
+
+variable "lambda_role_arn" {
+  description = "IAM role ARN assumed by the Lambda functions in the pipeline."
+  type        = string
+}
+
+variable "lambda_layers" {
+  description = "List of Lambda layer ARNs shared across pipeline functions."
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_default_timeout" {
+  description = "Default timeout (in seconds) applied to Lambda functions when not specified individually."
+  type        = number
+  default     = 300
+}
+
+variable "lambda_default_memory_size" {
+  description = "Default memory size (in MB) for Lambda functions when not specified individually."
+  type        = number
+  default     = 512
+}
+
+variable "lambda_environment_defaults" {
+  description = "Environment variables merged into every Lambda function in the pipeline."
+  type        = map(string)
+  default     = {}
+}
+
+variable "notify_slack_secret_arn" {
+  description = "Secrets Manager ARN that stores the Slack webhook for notifications. When provided it is injected into the notify Lambda function as SLACK_WEBHOOK_SECRET_ARN."
+  type        = string
+  default     = ""
+}
+
+variable "redshift_secret_arn" {
+  description = "Secrets Manager ARN that stores the Redshift credentials. Injected into the compute/readmit Lambda and dbt task environment when provided."
+  type        = string
+  default     = ""
+}
+
+variable "export_parquet_target_bucket" {
+  description = "Default bucket name used by the export parquet Lambda. When supplied it is added as TARGET_BUCKET environment variable."
+  type        = string
+  default     = ""
+}
+
+variable "lambda_functions" {
+  description = <<DESC
+Map describing the Lambda functions that compose the ELT pipeline. The keys must include
+`validate_manifest`, `copy_raw`, `compute_readmit`, `export_parquet`, and `notify`.
+Each object accepts the following attributes:
+  * function_name  - Optional explicit Lambda function name. Defaults to `dpc-<key>`.
+  * description    - Optional description for the Lambda function.
+  * handler        - Lambda handler string.
+  * runtime        - Lambda runtime identifier.
+  * package_key    - S3 object key that contains the deployment package zip file.
+  * source_code_hash - Optional base64-encoded deployment package hash.
+  * timeout        - Optional override timeout in seconds.
+  * memory_size    - Optional override memory size in MB.
+  * environment    - Optional map of extra environment variables specific to the function.
+DESC
+  type = map(object({
+    function_name    = optional(string)
+    description      = optional(string)
+    handler          = string
+    runtime          = string
+    package_key      = string
+    source_code_hash = optional(string)
+    timeout          = optional(number)
+    memory_size      = optional(number)
+    environment      = optional(map(string), {})
+  }))
+
+  validation {
+    condition = alltrue([
+      for required in ["validate_manifest", "copy_raw", "compute_readmit", "export_parquet", "notify"] :
+      contains(keys(var.lambda_functions), required)
+    ])
+    error_message = "lambda_functions must include validate_manifest, copy_raw, compute_readmit, export_parquet, and notify entries."
+  }
+}
+
+variable "lambda_publish" {
+  description = "Whether to publish a new version on each Lambda deployment."
+  type        = bool
+  default     = false
+}
+
+variable "sns_topic_name" {
+  description = "Name of the SNS topic that aggregates pipeline notifications."
+  type        = string
+}
+
+variable "sns_subscription_raw_message_delivery" {
+  description = "Whether the Lambda subscription receives raw SNS messages."
+  type        = bool
+  default     = false
+}
+
+variable "state_machine_name" {
+  description = "Name assigned to the Step Functions state machine."
+  type        = string
+}
+
+variable "state_machine_role_arn" {
+  description = "IAM role ARN assumed by the Step Functions state machine."
+  type        = string
+}
+
+variable "state_machine_comment" {
+  description = "Optional comment stored in the Step Functions definition for documentation."
+  type        = string
+  default     = "DPC ELT pipeline"
+}
+
+variable "enable_rollback_truncate" {
+  description = "When true the RollbackStage result indicates that downstream processes should perform TRUNCATE operations before a retry."
+  type        = bool
+  default     = false
+}
+
+variable "rollback_statements" {
+  description = "Optional list of SQL statements that would be executed during rollback in a production deployment. They are surfaced as metadata in the Pass state."
+  type        = list(string)
+  default     = []
+}
+
+variable "eventbridge_schedule_expression" {
+  description = "Schedule expression that triggers the daily pipeline execution via EventBridge."
+  type        = string
+}
+
+variable "eventbridge_role_arn" {
+  description = "IAM role ARN used by EventBridge to start the Step Functions execution."
+  type        = string
+}
+
+variable "eventbridge_input" {
+  description = "Static JSON payload provided when EventBridge starts the pipeline."
+  type        = map(any)
+  default     = {}
+}
+
+variable "dbt_repository_name" {
+  description = "Name of the ECR repository that stores the dbt runner container image."
+  type        = string
+  default     = "dpc-dbt-runner"
+}
+
+variable "dbt_repository_force_delete" {
+  description = "Whether to allow Terraform to delete the ECR repository even when images are present."
+  type        = bool
+  default     = false
+}
+
+variable "dbt_task_family" {
+  description = "Family name for the dbt ECS task definition."
+  type        = string
+  default     = "dpc-dbt-runner"
+}
+
+variable "dbt_task_cpu" {
+  description = "CPU units allocated to the dbt ECS task."
+  type        = number
+  default     = 1024
+}
+
+variable "dbt_task_memory" {
+  description = "Memory (in MiB) allocated to the dbt ECS task."
+  type        = number
+  default     = 2048
+}
+
+variable "dbt_execution_role_arn" {
+  description = "IAM execution role ARN used by the dbt ECS task definition."
+  type        = string
+}
+
+variable "dbt_task_role_arn" {
+  description = "IAM task role ARN that grants the dbt container access to the Data API and Secrets Manager."
+  type        = string
+}
+
+variable "dbt_container_name" {
+  description = "Name assigned to the dbt container within the ECS task definition."
+  type        = string
+  default     = "dbt-runner"
+}
+
+variable "dbt_container_image" {
+  description = "Full image URI for the dbt container. When empty the module references the repository created within this module."
+  type        = string
+  default     = ""
+}
+
+variable "dbt_container_command" {
+  description = "Default command baked into the dbt task definition. The Step Functions task can override this at runtime."
+  type        = list(string)
+  default     = ["dbt", "run"]
+}
+
+variable "dbt_environment_defaults" {
+  description = "Environment variables embedded in the dbt container definition."
+  type        = map(string)
+  default     = {}
+}
+
+variable "dbt_environment_overrides" {
+  description = "Additional environment variables merged into the dbt container definition."
+  type        = map(string)
+  default     = {}
+}
+
+variable "dbt_state_machine_command" {
+  description = "Command executed by the ECS RunTask state within Step Functions."
+  type        = list(string)
+  default     = ["dbt", "run"]
+}
+
+variable "dbt_state_machine_environment" {
+  description = "Additional environment overrides supplied by the Step Functions RunTask state. Set value for static literals or value_path to reference the state input."
+  type = list(object({
+    name       = string
+    value      = optional(string)
+    value_path = optional(string)
+  }))
+  default = []
+
+  validation {
+    condition = length(var.dbt_state_machine_environment) == 0 ? true : alltrue([
+      for item in var.dbt_state_machine_environment : (
+        (try(item.value, null) != null && try(item.value_path, null) == null) ||
+        (try(item.value, null) == null && try(item.value_path, null) != null)
+      )
+    ])
+    error_message = "Each dbt_state_machine_environment entry must define exactly one of value or value_path."
+  }
+}
+
+variable "dbt_log_configuration" {
+  description = "Optional log configuration block injected into the dbt container definition."
+  type        = any
+  default     = null
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster where the dbt task runs."
+  type        = string
+}
+
+variable "ecs_subnet_ids" {
+  description = "Subnet IDs assigned to the Fargate task network configuration."
+  type        = list(string)
+}
+
+variable "ecs_security_group_ids" {
+  description = "Security group IDs attached to the Fargate task."
+  type        = list(string)
+}
+
+variable "ecs_assign_public_ip" {
+  description = "When true the ECS task receives a public IP address."
+  type        = bool
+  default     = false
+}
+
+variable "manual_start_policy_name" {
+  description = "Name of the IAM policy that grants operators access to manually start the pipeline."
+  type        = string
+  default     = "dpc-pipeline-manual-start"
+}


### PR DESCRIPTION
## Summary
- add a reusable Terraform module that provisions the Lambda, Step Functions, ECS, SNS, and EventBridge pieces of the training ELT pipeline
- document module usage and configuration knobs for aligning with the minimal task 03 walkthrough
- expose outputs for the provisioned resources so other stacks can reference the pipeline artifacts

## Testing
- terraform fmt *(fails: terraform binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f85601aa588329ae089d547a921b0e