### PR TITLE
Initialize minimal dbt project

### DIFF
--- a/dbt/dpc_learning/dbt_project.yml
+++ b/dbt/dpc_learning/dbt_project.yml
@@ -1,0 +1,32 @@
+name: dpc_learning
+version: 0.1.0
+config-version: 2
+profile: dpc_learning
+model-paths:
+  - models
+seed-paths:
+  - seeds
+macro-paths:
+  - macros
+target-path: /tmp/dbt/target
+clean-targets:
+  - target
+  - dbt_packages
+models:
+  dpc_learning:
+    +materialized: table
+    raw:
+      +schema: raw
+      +materialized: view
+    stage:
+      +schema: stage
+      +materialized: incremental
+    mart:
+      +schema: mart
+      +materialized: table
+    ref:
+      +schema: ref
+      +materialized: table
+seeds:
+  dpc_learning:
+    +schema: ref

--- a/dbt/dpc_learning/models/mart/fact_case_summary.sql
+++ b/dbt/dpc_learning/models/mart/fact_case_summary.sql
@@ -1,0 +1,26 @@
+{{ config(
+    materialized='table',
+    tags=['layer:mart', 'domain:inpatient'],
+    meta={'owner': 'analytics', 'dq_owner': 'analytics', 'refresh_frequency': 'daily'}
+) }}
+
+with cases as (
+    select
+        facility_cd,
+        data_id,
+        length_of_stay,
+        total_points,
+        case when length_of_stay <= 30 then 1 else 0 end as readmit_30d_flag
+    from {{ ref('stg_y1_case') }}
+)
+
+select
+    c.facility_cd,
+    f.facility_name,
+    count(distinct c.data_id) as case_count,
+    sum(c.total_points) as total_points,
+    avg(c.length_of_stay) as avg_length_of_stay,
+    sum(c.readmit_30d_flag) as readmit_30d_cases
+from cases c
+left join {{ ref('dim_facility') }} f on c.facility_cd = f.facility_cd
+group by 1, 2

--- a/dbt/dpc_learning/models/mart/schema.yml
+++ b/dbt/dpc_learning/models/mart/schema.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: fact_case_summary
+    description: "症例単位の集計結果ファクト"
+    tags: ['layer:mart', 'domain:inpatient']
+    meta:
+      owner: analytics
+      dq_owner: analytics
+      refresh_frequency: daily
+    columns:
+      - name: facility_cd
+        description: "施設コード"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_facility')
+              field: facility_cd
+      - name: case_count
+        description: "症例数"
+        tests:
+          - not_null
+      - name: total_points
+        description: "診療点数合計"
+        tests:
+          - not_null
+      - name: readmit_30d_cases
+        description: "30日以内再入院症例数"
+        tests:
+          - not_null

--- a/dbt/dpc_learning/models/raw/sources.yml
+++ b/dbt/dpc_learning/models/raw/sources.yml
@@ -1,0 +1,17 @@
+version: 2
+sources:
+  - name: raw
+    database: {{ env_var('DBT_RS_DATABASE') }}
+    schema: raw
+    tables:
+      - name: y1_inpatient
+        description: "様式1レセプトのインポート結果"
+        meta:
+          owner: data-eng
+        columns:
+          - name: facility_cd
+            description: "DPC提出施設コード"
+          - name: data_id
+            description: "症例識別子"
+          - name: admission_date
+            description: "入院日"

--- a/dbt/dpc_learning/models/raw/src_y1_inpatient.sql
+++ b/dbt/dpc_learning/models/raw/src_y1_inpatient.sql
@@ -1,0 +1,8 @@
+{{ config(
+    materialized='view',
+    tags=['layer:raw', 'domain:inpatient'],
+    meta={'owner': 'data-eng'}
+) }}
+
+select *
+from {{ source('raw', 'y1_inpatient') }}

--- a/dbt/dpc_learning/models/ref/dim_facility.sql
+++ b/dbt/dpc_learning/models/ref/dim_facility.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    tags=['layer:ref', 'domain:shared'],
+    meta={'owner': 'data-eng', 'refresh_frequency': 'weekly'}
+) }}
+
+select
+    facility_cd,
+    facility_name,
+    prefecture
+from {{ ref('facility_master') }}

--- a/dbt/dpc_learning/models/ref/schema.yml
+++ b/dbt/dpc_learning/models/ref/schema.yml
@@ -1,0 +1,18 @@
+version: 2
+models:
+  - name: dim_facility
+    description: "施設マスタディメンション"
+    tags: ['layer:ref', 'domain:shared']
+    meta:
+      owner: data-eng
+      refresh_frequency: weekly
+    columns:
+      - name: facility_cd
+        description: "施設コード"
+        tests:
+          - not_null
+          - unique
+      - name: facility_name
+        description: "施設名称"
+        tests:
+          - not_null

--- a/dbt/dpc_learning/models/stage/schema.yml
+++ b/dbt/dpc_learning/models/stage/schema.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: stg_y1_case
+    description: "様式1データを症例単位に整形したステージングモデル"
+    tags: ['layer:stage', 'domain:inpatient']
+    meta:
+      owner: data-eng
+      dq_owner: analytics
+    columns:
+      - name: facility_cd
+        description: "DPC提出施設コード"
+        tests:
+          - not_null
+      - name: data_id
+        description: "症例識別子"
+        tests:
+          - not_null
+          - unique:
+              combination_of_columns: true
+      - name: admission_date
+        description: "入院日"
+        tests:
+          - not_null

--- a/dbt/dpc_learning/models/stage/stg_y1_case.sql
+++ b/dbt/dpc_learning/models/stage/stg_y1_case.sql
@@ -1,0 +1,40 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['facility_cd', 'data_id'],
+    on_schema_change='sync_all_columns',
+    tags=['layer:stage', 'domain:inpatient'],
+    meta={'owner': 'data-eng', 'dq_owner': 'analytics'}
+) }}
+
+with base as (
+    select
+        facility_cd,
+        data_id,
+        admission_date,
+        discharge_date,
+        datediff(day, admission_date, discharge_date) + 1 as length_of_stay,
+        sex_code,
+        birth_date,
+        dpc_code,
+        main_icd10,
+        total_points,
+        current_timestamp as ingested_at
+    from {{ ref('src_y1_inpatient') }}
+)
+
+select
+    facility_cd,
+    data_id,
+    admission_date,
+    discharge_date,
+    length_of_stay,
+    sex_code,
+    birth_date,
+    dpc_code,
+    main_icd10,
+    total_points,
+    ingested_at
+from base
+{% if is_incremental() %}
+where ingested_at > (select coalesce(max(ingested_at), '1900-01-01') from {{ this }})
+{% endif %}

--- a/dbt/dpc_learning/packages.yml
+++ b/dbt/dpc_learning/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: ">=1.1.0,<2.0.0"

--- a/dbt/dpc_learning/profiles.yml
+++ b/dbt/dpc_learning/profiles.yml
@@ -1,0 +1,13 @@
+dpc_learning:
+  target: dev
+  outputs:
+    dev:
+      type: redshift
+      method: data_api
+      workgroup: {{ env_var('DBT_RS_WORKGROUP') }}
+      region: {{ env_var('DBT_RS_REGION') }}
+      database: {{ env_var('DBT_RS_DATABASE') }}
+      schema: stage
+      secret_arn: {{ env_var('DBT_RS_SECRET_ARN') }}
+      threads: 4
+      connect_timeout: 10

--- a/dbt/dpc_learning/requirements.txt
+++ b/dbt/dpc_learning/requirements.txt
@@ -1,0 +1,2 @@
+dbt-core==1.6.6
+dbt-redshift==1.6.2

--- a/dbt/dpc_learning/seeds/facility_master.csv
+++ b/dbt/dpc_learning/seeds/facility_master.csv
@@ -1,0 +1,3 @@
+facility_cd,facility_name,prefecture
+100001,Tokyo General Hospital,Tokyo
+100002,Osaka Central Clinic,Osaka


### PR DESCRIPTION
## Summary
- add a minimal dbt project skeleton for the dpc_learning warehouse
- define raw, stage, mart, and reference models with schema tests and seeds
- configure Redshift Serverless data API profile and dependencies for container execution

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8560ca14c83298099067ca4f90c0f