### PR TITLE
Add minimal operations monitoring and CI automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: IaC and dbt checks
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  terraform:
+    name: Terraform validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform fmt
+        run: terraform -chdir=infra/terraform/dev fmt -check
+
+      - name: Terraform validate
+        run: terraform -chdir=infra/terraform/dev validate
+
+      - name: Terraform plan
+        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: terraform -chdir=infra/terraform/dev plan -input=false
+
+  dbt:
+    name: dbt compilation
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('dbt_project.yml') != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dbt dependencies
+        run: pip install dbt-redshift==1.7.8
+
+      - name: dbt deps
+        run: dbt deps
+
+      - name: dbt compile
+        run: dbt compile

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -1,0 +1,15 @@
+module "operations" {
+  source = "../modules/operations"
+
+  environment                     = var.environment
+  state_machine_arn               = var.state_machine_arn
+  alert_topic_arn                 = var.alert_topic_arn
+  lambda_subscription_arn         = var.lambda_subscription_arn
+  email_subscribers               = var.email_subscribers
+  redshift_workgroup_name         = var.redshift_workgroup_name
+  step_functions_alarm_threshold  = var.step_functions_alarm_threshold
+  redshift_rpu_threshold          = var.redshift_rpu_threshold
+  tags                            = {
+    Project = "dpc-learning"
+  }
+}

--- a/infra/terraform/dev/outputs.tf
+++ b/infra/terraform/dev/outputs.tf
@@ -1,0 +1,9 @@
+output "step_functions_alarm_arn" {
+  description = "ARN of the CloudWatch alarm configured for Step Functions failures."
+  value       = module.operations.step_functions_alarm_arn
+}
+
+output "redshift_rpu_alarm_arn" {
+  description = "ARN of the CloudWatch alarm configured for Redshift RPU utilization."
+  value       = module.operations.redshift_rpu_alarm_arn
+}

--- a/infra/terraform/dev/providers.tf
+++ b/infra/terraform/dev/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -1,0 +1,53 @@
+variable "aws_region" {
+  description = "AWS region used by the development environment."
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "environment" {
+  description = "Logical environment name propagated to modules."
+  type        = string
+  default     = "dev"
+}
+
+variable "state_machine_arn" {
+  description = "ARN of the Step Functions state machine executed by the ELT pipeline."
+  type        = string
+  default     = "arn:aws:states:ap-northeast-1:123456789012:stateMachine:dpc-learning-pipeline"
+}
+
+variable "alert_topic_arn" {
+  description = "SNS topic ARN that delivers learning platform alerts."
+  type        = string
+  default     = "arn:aws:sns:ap-northeast-1:123456789012:dpc-learning-alerts"
+}
+
+variable "lambda_subscription_arn" {
+  description = "ARN of the dpc-notify Lambda function subscribed to alert notifications."
+  type        = string
+  default     = null
+}
+
+variable "email_subscribers" {
+  description = "Optional list of email recipients for alert notifications."
+  type        = list(string)
+  default     = []
+}
+
+variable "redshift_workgroup_name" {
+  description = "Redshift Serverless workgroup monitored for capacity usage."
+  type        = string
+  default     = "dpc-learning"
+}
+
+variable "step_functions_alarm_threshold" {
+  description = "Threshold for the number of Step Functions failures before raising an alarm."
+  type        = number
+  default     = 1
+}
+
+variable "redshift_rpu_threshold" {
+  description = "Threshold for Redshift Serverless RPU utilization before raising an alarm."
+  type        = number
+  default     = 80
+}

--- a/infra/terraform/dev/versions.tf
+++ b/infra/terraform/dev/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/terraform/modules/operations/main.tf
+++ b/infra/terraform/modules/operations/main.tf
@@ -1,0 +1,93 @@
+terraform {
+  required_version = ">= 1.4.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  alarm_prefix = var.alarm_name_prefix != "" ? var.alarm_name_prefix : "dpc-${var.environment}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "step_functions_failed" {
+  alarm_name          = "${local.alarm_prefix}-stepfunctions-failed"
+  alarm_description   = "Alerts when Step Functions executions fail in the ${var.environment} environment."
+  namespace           = "AWS/States"
+  metric_name         = "ExecutionsFailed"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.step_functions_alarm_threshold
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    StateMachineArn = var.state_machine_arn
+  }
+
+  alarm_actions             = [var.alert_topic_arn]
+  ok_actions                = [var.alert_topic_arn]
+  insufficient_data_actions = []
+
+  tags = merge(var.tags, {
+    "Component"   = "operations"
+    "Environment" = var.environment
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "redshift_rpu" {
+  alarm_name          = "${local.alarm_prefix}-redshift-rpu-high"
+  alarm_description   = "Alerts when Redshift Serverless RPU utilization remains above the defined threshold."
+  namespace           = "AWS/RedshiftServerless"
+  metric_name         = "RPUUtilization"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.redshift_rpu_threshold
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    WorkgroupName = var.redshift_workgroup_name
+  }
+
+  alarm_actions             = [var.alert_topic_arn]
+  ok_actions                = [var.alert_topic_arn]
+  insufficient_data_actions = []
+
+  tags = merge(var.tags, {
+    "Component"   = "operations"
+    "Environment" = var.environment
+  })
+}
+
+resource "aws_sns_topic_subscription" "lambda" {
+  count = var.lambda_subscription_arn == null ? 0 : 1
+
+  topic_arn = var.alert_topic_arn
+  protocol  = "lambda"
+  endpoint  = var.lambda_subscription_arn
+}
+
+resource "aws_lambda_permission" "allow_sns" {
+  count = var.lambda_subscription_arn == null ? 0 : 1
+
+  statement_id  = "AllowExecutionFromSNS-${var.environment}"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_subscription_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.alert_topic_arn
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  for_each = { for address in var.email_subscribers : address => address }
+
+  topic_arn = var.alert_topic_arn
+  protocol  = "email"
+  endpoint  = each.value
+}

--- a/infra/terraform/modules/operations/outputs.tf
+++ b/infra/terraform/modules/operations/outputs.tf
@@ -1,0 +1,20 @@
+output "step_functions_alarm_arn" {
+  description = "ARN of the CloudWatch alarm that monitors Step Functions execution failures."
+  value       = aws_cloudwatch_metric_alarm.step_functions_failed.arn
+}
+
+output "redshift_rpu_alarm_arn" {
+  description = "ARN of the CloudWatch alarm that monitors Redshift Serverless RPU utilization."
+  value       = aws_cloudwatch_metric_alarm.redshift_rpu.arn
+}
+
+output "lambda_subscription_arn" {
+  description = "ARN of the Lambda subscription that receives SNS notifications."
+  value       = var.lambda_subscription_arn
+  sensitive   = true
+}
+
+output "email_subscription_endpoints" {
+  description = "List of email addresses subscribed to the alert topic."
+  value       = [for subscription in aws_sns_topic_subscription.email : subscription.endpoint]
+}

--- a/infra/terraform/modules/operations/variables.tf
+++ b/infra/terraform/modules/operations/variables.tf
@@ -1,0 +1,55 @@
+variable "environment" {
+  description = "Deployment environment identifier used in alarm names and descriptions."
+  type        = string
+}
+
+variable "alarm_name_prefix" {
+  description = "Optional prefix applied to all alarm names. Defaults to dpc-<environment> when not provided."
+  type        = string
+  default     = ""
+}
+
+variable "state_machine_arn" {
+  description = "ARN of the Step Functions state machine to monitor for failed executions."
+  type        = string
+}
+
+variable "step_functions_alarm_threshold" {
+  description = "Number of failed Step Functions executions within the evaluation period that should trigger the alarm."
+  type        = number
+  default     = 1
+}
+
+variable "redshift_workgroup_name" {
+  description = "Name of the Redshift Serverless workgroup to monitor for RPU utilization."
+  type        = string
+}
+
+variable "redshift_rpu_threshold" {
+  description = "Percentage of RPU utilization that should trigger the alarm."
+  type        = number
+  default     = 80
+}
+
+variable "alert_topic_arn" {
+  description = "ARN of the SNS topic that forwards alerts to downstream subscribers."
+  type        = string
+}
+
+variable "lambda_subscription_arn" {
+  description = "ARN of the Lambda function (for example dpc-notify) that should receive SNS notifications."
+  type        = string
+  default     = null
+}
+
+variable "email_subscribers" {
+  description = "Optional list of email addresses that should receive alarm notifications."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to supported resources created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/operations/README.md
+++ b/operations/README.md
@@ -1,0 +1,31 @@
+# Operations Runbook (Minimal)
+
+この Runbook は学習用環境での ELT パイプライン監視と一次対応をまとめたものです。docs/09_operations.md の詳細設計を簡易化し、すぐに参照できる手順を提供します。
+
+## 1. アラート受信後の一次切り分け
+1. CloudWatch アラームの内容を確認します。`dpc-learning-alerts` SNS トピック経由で Slack と Lambda (`dpc-notify`) に通知されます。
+2. Step Functions 失敗アラームの場合は、AWS Step Functions コンソールで該当実行の失敗ステートを特定します。
+3. Redshift RPU 利用率アラームの場合は、Redshift Serverless コンソールで現在の Workgroup 状況と同時実行クエリを確認します。
+
+## 2. 復旧フロー
+- **Step Functions 実行失敗**
+  - エラー内容を確認し、リトライ可能な場合は `StartExecution` で再実行します。
+  - 入力データに起因する失敗（例: S3 マニフェスト破損）の場合は、該当ファイルを差し替えたうえで再実行します。
+- **Redshift RPU 利用率スパイク**
+  - `SVL_QLOG` や `STV_RECENTS` を参照し、負荷の高いクエリを特定します。
+  - 長時間実行クエリがある場合はキャンセルし、必要に応じて dbt モデルの再実行順序を調整します。
+- **dbt / モデル処理の失敗**
+  - dbt Cloud もしくは ECS タスクのログを確認し、該当モデルのみを `dbt run --select <model>` で再実行後、全体バッチを再実行します。
+
+## 3. 二次対応と共有
+1. 必要に応じて S3 の原本データを過去の成功バージョンに差し替え、`COPY` を再実行します。
+2. Redshift の `VACUUM` / `ANALYZE` を手動実行して統計情報を整えます。
+3. 障害内容と対応状況をチームに共有し、事後レビューの議事録を作成します。
+
+## 4. 将来の改善アイデア
+- カスタムメトリクス（例: `ELTExecutionDelay`）の実装とアラート連携。
+- dbt の `state:modified` 実行結果を CloudWatch Logs へエクスポートして検索性を向上。
+
+## 5. Runbook 管理ツール
+現時点では本リポジトリで Runbook を管理し、学習完了後に Confluence と Notion を比較して正式なナレッジベースを選定します。
+


### PR DESCRIPTION
## Summary
- add a Terraform operations module that configures CloudWatch alarms and alert subscriptions
- wire the development stack to the operations module with placeholder variables for the learning environment
- document the minimal runbook and introduce a CI workflow for Terraform and dbt checks

## Testing
- not run (Terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f856334acc8329ae1fbfc0d29f8781