### PR TITLE
Refine operations monitoring module integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: IaC and dbt checks
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  terraform:
+    name: Terraform validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform fmt
+        run: terraform -chdir=infra/terraform/dev fmt -check
+
+      - name: Terraform validate
+        run: terraform -chdir=infra/terraform/dev validate
+
+      - name: Terraform plan
+        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: terraform -chdir=infra/terraform/dev plan -input=false
+
+  dbt:
+    name: dbt compilation
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('dbt_project.yml') != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dbt dependencies
+        run: pip install dbt-redshift==1.7.8
+
+      - name: dbt deps
+        run: dbt deps
+
+      - name: dbt compile
+        run: dbt compile

--- a/infra/terraform/dev/operations.tf
+++ b/infra/terraform/dev/operations.tf
@@ -1,0 +1,14 @@
+module "operations" {
+  source = "../modules/operations"
+
+  environment                    = var.environment
+  alarm_name_prefix              = var.operations_alarm_name_prefix
+  state_machine_arn              = var.operations_state_machine_arn
+  alert_topic_arn                = var.operations_alert_topic_arn
+  lambda_subscription_arn        = var.operations_lambda_subscription_arn
+  email_subscribers              = var.operations_email_subscribers
+  redshift_workgroup_name        = var.operations_redshift_workgroup_name
+  step_functions_alarm_threshold = var.operations_step_functions_alarm_threshold
+  redshift_rpu_threshold         = var.operations_redshift_rpu_threshold
+  tags                           = var.default_tags
+}

--- a/infra/terraform/dev/operations_outputs.tf
+++ b/infra/terraform/dev/operations_outputs.tf
@@ -1,0 +1,9 @@
+output "operations_step_functions_alarm_arn" {
+  description = "ARN of the CloudWatch alarm configured for Step Functions failures."
+  value       = module.operations.step_functions_alarm_arn
+}
+
+output "operations_redshift_rpu_alarm_arn" {
+  description = "ARN of the CloudWatch alarm configured for Redshift RPU utilization."
+  value       = module.operations.redshift_rpu_alarm_arn
+}

--- a/infra/terraform/dev/operations_variables.tf
+++ b/infra/terraform/dev/operations_variables.tf
@@ -1,0 +1,47 @@
+variable "operations_alarm_name_prefix" {
+  description = "Optional prefix used for operations alarm names."
+  type        = string
+  default     = ""
+}
+
+variable "operations_state_machine_arn" {
+  description = "ARN of the Step Functions state machine executed by the ELT pipeline."
+  type        = string
+  default     = "arn:aws:states:ap-northeast-1:123456789012:stateMachine:dpc-learning-pipeline"
+}
+
+variable "operations_alert_topic_arn" {
+  description = "SNS topic ARN that delivers learning platform alerts."
+  type        = string
+  default     = "arn:aws:sns:ap-northeast-1:123456789012:dpc-learning-alerts"
+}
+
+variable "operations_lambda_subscription_arn" {
+  description = "ARN of the dpc-notify Lambda function subscribed to alert notifications."
+  type        = string
+  default     = null
+}
+
+variable "operations_email_subscribers" {
+  description = "Optional list of email recipients for alert notifications."
+  type        = list(string)
+  default     = []
+}
+
+variable "operations_redshift_workgroup_name" {
+  description = "Redshift Serverless workgroup monitored for capacity usage."
+  type        = string
+  default     = "dpc-learning"
+}
+
+variable "operations_step_functions_alarm_threshold" {
+  description = "Threshold for the number of Step Functions failures before raising an alarm."
+  type        = number
+  default     = 1
+}
+
+variable "operations_redshift_rpu_threshold" {
+  description = "Threshold for Redshift Serverless RPU utilization before raising an alarm."
+  type        = number
+  default     = 80
+}

--- a/infra/terraform/dev/providers.tf
+++ b/infra/terraform/dev/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  description = "AWS region used by the development environment."
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "environment" {
+  description = "Logical environment name propagated to modules."
+  type        = string
+  default     = "dev"
+}
+
+variable "default_tags" {
+  description = "Default tags applied to Terraform-managed resources."
+  type        = map(string)
+  default = {
+    Project = "dpc-learning"
+  }
+}

--- a/infra/terraform/dev/versions.tf
+++ b/infra/terraform/dev/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/infra/terraform/modules/operations/main.tf
+++ b/infra/terraform/modules/operations/main.tf
@@ -1,0 +1,96 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  alarm_prefix = length(trimspace(var.alarm_name_prefix)) > 0 ? trimspace(var.alarm_name_prefix) : "dpc-${var.environment}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "step_functions_failed" {
+  alarm_name          = "${local.alarm_prefix}-stepfunctions-failed"
+  alarm_description   = "Alerts when Step Functions executions fail in the ${var.environment} environment."
+  namespace           = "AWS/States"
+  metric_name         = "ExecutionsFailed"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.step_functions_alarm_threshold
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    StateMachineArn = var.state_machine_arn
+  }
+
+  alarm_actions             = [var.alert_topic_arn]
+  ok_actions                = [var.alert_topic_arn]
+  insufficient_data_actions = []
+
+  tags = merge(var.tags, {
+    Component   = "operations"
+    Environment = var.environment
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "redshift_rpu" {
+  alarm_name          = "${local.alarm_prefix}-redshift-rpu-high"
+  alarm_description   = "Alerts when Redshift Serverless RPU utilization remains above the defined threshold."
+  namespace           = "AWS/RedshiftServerless"
+  metric_name         = "RPUUtilization"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.redshift_rpu_threshold
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    WorkgroupName = var.redshift_workgroup_name
+  }
+
+  alarm_actions             = [var.alert_topic_arn]
+  ok_actions                = [var.alert_topic_arn]
+  insufficient_data_actions = []
+
+  tags = merge(var.tags, {
+    Component   = "operations"
+    Environment = var.environment
+  })
+}
+
+resource "aws_lambda_permission" "allow_sns" {
+  count = var.lambda_subscription_arn == null ? 0 : 1
+
+  statement_id  = "AllowExecutionFromSNS-${var.environment}"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_subscription_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.alert_topic_arn
+}
+
+resource "aws_sns_topic_subscription" "lambda" {
+  count = var.lambda_subscription_arn == null ? 0 : 1
+
+  topic_arn = var.alert_topic_arn
+  protocol  = "lambda"
+  endpoint  = var.lambda_subscription_arn
+
+  depends_on = [aws_lambda_permission.allow_sns]
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  for_each = { for address in var.email_subscribers : address => address }
+
+  topic_arn = var.alert_topic_arn
+  protocol  = "email"
+  endpoint  = each.value
+}

--- a/infra/terraform/modules/operations/outputs.tf
+++ b/infra/terraform/modules/operations/outputs.tf
@@ -1,0 +1,19 @@
+output "step_functions_alarm_arn" {
+  description = "ARN of the CloudWatch alarm that monitors Step Functions execution failures."
+  value       = aws_cloudwatch_metric_alarm.step_functions_failed.arn
+}
+
+output "redshift_rpu_alarm_arn" {
+  description = "ARN of the CloudWatch alarm that monitors Redshift Serverless RPU utilization."
+  value       = aws_cloudwatch_metric_alarm.redshift_rpu.arn
+}
+
+output "lambda_permission_statement_id" {
+  description = "Statement identifier granted for SNS to invoke the Lambda target."
+  value       = try(aws_lambda_permission.allow_sns[0].statement_id, null)
+}
+
+output "email_subscription_endpoints" {
+  description = "List of email addresses subscribed to the alert topic."
+  value       = [for subscription in aws_sns_topic_subscription.email : subscription.endpoint]
+}

--- a/infra/terraform/modules/operations/variables.tf
+++ b/infra/terraform/modules/operations/variables.tf
@@ -1,0 +1,55 @@
+variable "environment" {
+  description = "Deployment environment identifier used in alarm names and descriptions."
+  type        = string
+}
+
+variable "alarm_name_prefix" {
+  description = "Optional prefix applied to all alarm names. Defaults to dpc-<environment> when not provided."
+  type        = string
+  default     = ""
+}
+
+variable "state_machine_arn" {
+  description = "ARN of the Step Functions state machine to monitor for failed executions."
+  type        = string
+}
+
+variable "step_functions_alarm_threshold" {
+  description = "Number of failed Step Functions executions within the evaluation period that should trigger the alarm."
+  type        = number
+  default     = 1
+}
+
+variable "redshift_workgroup_name" {
+  description = "Name of the Redshift Serverless workgroup to monitor for RPU utilization."
+  type        = string
+}
+
+variable "redshift_rpu_threshold" {
+  description = "Percentage of RPU utilization that should trigger the alarm."
+  type        = number
+  default     = 80
+}
+
+variable "alert_topic_arn" {
+  description = "ARN of the SNS topic that forwards alerts to downstream subscribers."
+  type        = string
+}
+
+variable "lambda_subscription_arn" {
+  description = "ARN of the Lambda function (for example dpc-notify) that should receive SNS notifications."
+  type        = string
+  default     = null
+}
+
+variable "email_subscribers" {
+  description = "Optional list of email addresses that should receive alarm notifications."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to supported resources created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/operations/README.md
+++ b/operations/README.md
@@ -1,0 +1,32 @@
+# Operations Runbook (Minimal)
+
+この Runbook は学習用環境における ELT パイプライン監視と一次対応の手順をまとめたものです。詳細設計は docs/09_operations.md に整理
+されており、ここでは日常的な障害対応の流れだけを簡潔に記載します。
+
+## 1. アラート受信後の一次切り分け
+1. Slack の `#dpc-alerts` チャンネルで SNS (`dpc-learning-alerts`) 経由の通知を確認します。Lambda (`dpc-notify`) にも同じイベントが配信されます。
+2. Step Functions 失敗アラームの場合は、AWS Step Functions コンソールで該当実行のエラー詳細を確認します。
+3. Redshift RPU 利用率アラームの場合は、Redshift Serverless の Workgroup 画面で同時実行クエリと直近メトリクスを確認します。
+
+## 2. 復旧フロー
+- **Step Functions 実行失敗**
+  - エラーログを確認し、データ不備が疑われる場合は S3 の原本を差し替えてから `StartExecution` で再実行します。
+  - 再実行で改善しない場合は該当 Lambda / Glue ジョブのコードを確認し、修正後に再デプロイします。
+- **Redshift RPU 利用率スパイク**
+  - `SVL_QLOG` と `STV_RECENTS` を確認し、負荷の高いクエリを特定します。
+  - 長時間実行クエリがあればキャンセルし、必要に応じて dbt モデルの実行順序を変更します。
+- **dbt / モデル処理失敗**
+  - CloudWatch Logs または dbt 実行ログを確認し、対象モデルのみ `dbt run --select <model>` で再実行後に全体バッチを再開します。
+
+## 3. 二次対応とチーム共有
+1. 必要に応じて S3 の成功アーカイブからデータを復旧し、再ロードを実施します。
+2. Redshift の `VACUUM` / `ANALYZE` を手動実行し、統計情報を整えます。
+3. 障害内容・原因・対策をチームへ共有し、事後レビューの議事録を残します。
+
+## 4. 今後の改善アイデア
+- `ELTExecutionDelay` などカスタムメトリクスの追加と通知連携。
+- Redshift Workgroup のクエリモニタリングルール整備による自動キャンセル。
+- dbt の `state:modified` 実行結果を CloudWatch Logs に出力し検索性を向上。
+
+## 5. Runbook 管理ツール
+本 Runbook は暫定的にリポジトリで管理しており、学習完了後に Confluence と Notion を比較検討して正式なナレッジベースを決定します。


### PR DESCRIPTION
## Summary
- refactor the dev Terraform stack to isolate operations variables, outputs, and module wiring for easier reuse
- tighten the operations module by normalizing alarm prefixes, sequencing Lambda permissions ahead of subscriptions, and exposing safe outputs
- refresh the minimal operations runbook to emphasize alert triage and follow-up steps

## Testing
- not run (Terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f856334acc8329ae1fbfc0d29f8781