### PR TITLE
Add operations monitoring module and CI automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: Infrastructure and dbt CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  terraform:
+    name: Terraform checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init (dev)
+        run: terraform -chdir=infra/terraform/dev init -backend=false
+
+      - name: Terraform validate (dev)
+        run: terraform -chdir=infra/terraform/dev validate
+
+      - name: Terraform init (operations example)
+        run: terraform -chdir=modules/operations/examples/basic init -backend=false
+
+      - name: Terraform plan (operations example)
+        run: terraform -chdir=modules/operations/examples/basic plan -lock=false -input=false
+
+  dbt:
+    name: dbt compile
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dbt/dpc_learning
+
+    env:
+      DBT_PROFILES_DIR: ${{ github.workspace }}/dbt/dpc_learning
+      DBT_RS_WORKGROUP: placeholder
+      DBT_RS_REGION: ap-northeast-1
+      DBT_RS_DATABASE: dpc_learning
+      DBT_RS_SECRET_ARN: arn:aws:secretsmanager:ap-northeast-1:000000000000:secret:placeholder
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dbt dependencies
+        run: pip install -r requirements.txt
+
+      - name: dbt deps
+        run: dbt deps
+
+      - name: dbt compile
+        run: dbt compile

--- a/modules/operations/README.md
+++ b/modules/operations/README.md
@@ -1,0 +1,60 @@
+# Operations Monitoring Module
+
+This Terraform module provisions a minimal set of CloudWatch alarms and notification plumbing for the DPC learning platform. It focuses on two critical signals:
+
+- **Step Functions execution failures** using the `ExecutionsFailed` metric.
+- **Redshift Serverless RPU utilization** to detect sustained capacity pressure.
+
+All alerts fan out through the existing `dpc-learning-alerts` SNS topic so they can reach Slack via the `dpc-notify` Lambda function and optional email subscribers.
+
+## Usage
+
+```hcl
+module "operations" {
+  source = "./modules/operations"
+
+  environment                  = var.environment
+  tags                         = local.tags
+  sns_topic_arn                = module.pipeline.sns_topic_arn
+  notify_lambda_arn            = module.pipeline.lambda_function_arns["notify"]
+  state_machine_arn            = module.pipeline.state_machine_arn
+  redshift_workgroup_name      = var.redshift_workgroup_name
+  email_subscribers            = ["alerts@example.com"]
+  send_ok_actions              = true
+  redshift_rpu_utilization_threshold = 85
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| --- | --- | --- | --- | --- |
+| `environment` | Environment identifier used for alarm naming (e.g. `dev`, `stg`, `prod`). | `string` | n/a | yes |
+| `tags` | Additional tags applied to alarm resources. | `map(string)` | `{}` | no |
+| `sns_topic_arn` | ARN of the SNS topic that fan-outs operations alerts. | `string` | n/a | yes |
+| `sns_raw_message_delivery` | Enables raw SNS message delivery for the Lambda subscription. | `bool` | `false` | no |
+| `email_delivery_policy` | Optional SNS delivery policy JSON applied to each email subscription. | `string` | `null` | no |
+| `notify_lambda_arn` | ARN of the `dpc-notify` Lambda function. | `string` | n/a | yes |
+| `email_subscribers` | Email addresses that should receive alert notifications. | `list(string)` | `[]` | no |
+| `state_machine_arn` | ARN of the Step Functions state machine monitored for failures. | `string` | n/a | yes |
+| `step_functions_failure_threshold` | Number of failed executions that triggers the alarm. | `number` | `1` | no |
+| `step_functions_evaluation_periods` | Number of periods evaluated for the Step Functions alarm. | `number` | `1` | no |
+| `step_functions_datapoints_to_alarm` | Datapoints that must breach for the Step Functions alarm to trigger. | `number` | `1` | no |
+| `step_functions_period_seconds` | Evaluation period (seconds) for the Step Functions metric. | `number` | `300` | no |
+| `step_functions_treat_missing_data` | Treatment of missing data for the Step Functions alarm. | `string` | `"notBreaching"` | no |
+| `redshift_workgroup_name` | Redshift Serverless workgroup name monitored for RPU utilization. | `string` | n/a | yes |
+| `redshift_rpu_utilization_threshold` | Average RPU utilization percentage that triggers the alarm. | `number` | `80` | no |
+| `redshift_rpu_evaluation_periods` | Number of periods evaluated for the Redshift alarm. | `number` | `1` | no |
+| `redshift_rpu_datapoints_to_alarm` | Datapoints that must breach for the Redshift alarm to trigger. | `number` | `1` | no |
+| `redshift_rpu_period_seconds` | Evaluation period (seconds) for the Redshift metric. | `number` | `300` | no |
+| `redshift_rpu_treat_missing_data` | Treatment of missing data for the Redshift alarm. | `string` | `"notBreaching"` | no |
+| `send_ok_actions` | When true, send recovery notifications to the same SNS topic. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `step_functions_alarm_arn` | ARN of the CloudWatch alarm for Step Functions failures. |
+| `redshift_rpu_alarm_arn` | ARN of the CloudWatch alarm for Redshift RPU utilization. |
+| `sns_lambda_subscription_arn` | ARN of the SNS subscription that invokes the notify Lambda. |
+| `sns_email_subscription_arns` | Map of email addresses to their SNS subscription ARNs. |

--- a/modules/operations/examples/basic/main.tf
+++ b/modules/operations/examples/basic/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "mock"
+  secret_key                  = "mock"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+}
+
+module "operations" {
+  source = "../.."
+
+  environment             = "ci"
+  tags                    = {
+    Project = "dpc-learning"
+  }
+  sns_topic_arn           = "arn:aws:sns:us-east-1:123456789012:dpc-learning-alerts"
+  notify_lambda_arn       = "arn:aws:lambda:us-east-1:123456789012:function:dpc-notify"
+  state_machine_arn       = "arn:aws:states:us-east-1:123456789012:stateMachine:dpc-pipeline"
+  redshift_workgroup_name = "dpc-learning"
+  email_subscribers       = ["alerts@example.com"]
+  send_ok_actions         = true
+}

--- a/modules/operations/main.tf
+++ b/modules/operations/main.tf
@@ -1,0 +1,92 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+locals {
+  alarm_name_prefix = "dpc-${var.environment}"
+  default_tags = merge(
+    {
+      Environment = var.environment
+    },
+    var.tags,
+  )
+}
+
+resource "aws_lambda_permission" "allow_sns_notify" {
+  statement_id  = "AllowExecutionFromSnsNotify"
+  action        = "lambda:InvokeFunction"
+  function_name = var.notify_lambda_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.sns_topic_arn
+}
+
+resource "aws_sns_topic_subscription" "notify_lambda" {
+  topic_arn = var.sns_topic_arn
+  protocol  = "lambda"
+  endpoint  = var.notify_lambda_arn
+
+  raw_message_delivery = var.sns_raw_message_delivery
+
+  depends_on = [aws_lambda_permission.allow_sns_notify]
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  for_each = { for email in var.email_subscribers : email => email }
+
+  topic_arn = var.sns_topic_arn
+  protocol  = "email"
+  endpoint  = each.value
+
+  delivery_policy = var.email_delivery_policy
+}
+
+resource "aws_cloudwatch_metric_alarm" "step_functions_failed" {
+  alarm_name          = "${local.alarm_name_prefix}-step-functions-failed"
+  alarm_description   = "Alerts when the Step Functions state machine reports failed executions."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = var.step_functions_evaluation_periods
+  datapoints_to_alarm = var.step_functions_datapoints_to_alarm
+  threshold           = var.step_functions_failure_threshold
+  treat_missing_data  = var.step_functions_treat_missing_data
+  metric_name         = "ExecutionsFailed"
+  namespace           = "AWS/States"
+  period              = var.step_functions_period_seconds
+  statistic           = "Sum"
+
+  dimensions = {
+    StateMachineArn = var.state_machine_arn
+  }
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = var.send_ok_actions ? [var.sns_topic_arn] : []
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "redshift_rpu_utilization" {
+  alarm_name          = "${local.alarm_name_prefix}-redshift-rpu-utilization"
+  alarm_description   = "Alerts when Redshift Serverless RPU utilization remains above the configured threshold."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.redshift_rpu_evaluation_periods
+  datapoints_to_alarm = var.redshift_rpu_datapoints_to_alarm
+  threshold           = var.redshift_rpu_utilization_threshold
+  treat_missing_data  = var.redshift_rpu_treat_missing_data
+  metric_name         = "RPUUtilization"
+  namespace           = "AWS/Redshift"
+  period              = var.redshift_rpu_period_seconds
+  statistic           = "Average"
+
+  dimensions = {
+    Workgroup = var.redshift_workgroup_name
+  }
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = var.send_ok_actions ? [var.sns_topic_arn] : []
+
+  tags = local.default_tags
+}

--- a/modules/operations/outputs.tf
+++ b/modules/operations/outputs.tf
@@ -1,0 +1,19 @@
+output "step_functions_alarm_arn" {
+  description = "ARN of the CloudWatch alarm monitoring Step Functions failures."
+  value       = aws_cloudwatch_metric_alarm.step_functions_failed.arn
+}
+
+output "redshift_rpu_alarm_arn" {
+  description = "ARN of the CloudWatch alarm monitoring Redshift RPU utilization."
+  value       = aws_cloudwatch_metric_alarm.redshift_rpu_utilization.arn
+}
+
+output "sns_lambda_subscription_arn" {
+  description = "ARN of the SNS subscription that invokes the notify Lambda."
+  value       = aws_sns_topic_subscription.notify_lambda.arn
+}
+
+output "sns_email_subscription_arns" {
+  description = "Map of email addresses to their SNS subscription ARNs."
+  value       = { for email, subscription in aws_sns_topic_subscription.email : email => subscription.arn }
+}

--- a/modules/operations/variables.tf
+++ b/modules/operations/variables.tf
@@ -1,0 +1,114 @@
+variable "environment" {
+  description = "Environment identifier used for alarm naming (e.g. dev, stg, prod)."
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags applied to alarm resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "sns_topic_arn" {
+  description = "ARN of the SNS topic that fan-outs operations alerts."
+  type        = string
+}
+
+variable "sns_raw_message_delivery" {
+  description = "Whether to enable raw message delivery for the Lambda SNS subscription."
+  type        = bool
+  default     = false
+}
+
+variable "email_delivery_policy" {
+  description = "Optional SNS delivery policy JSON for email subscriptions."
+  type        = string
+  default     = null
+}
+
+variable "notify_lambda_arn" {
+  description = "ARN of the dpc-notify Lambda function that relays alerts to Slack."
+  type        = string
+}
+
+variable "email_subscribers" {
+  description = "List of email addresses that should receive alert notifications."
+  type        = list(string)
+  default     = []
+}
+
+variable "state_machine_arn" {
+  description = "ARN of the Step Functions state machine monitored for failed executions."
+  type        = string
+}
+
+variable "step_functions_failure_threshold" {
+  description = "Number of failed executions that triggers the alarm."
+  type        = number
+  default     = 1
+}
+
+variable "step_functions_evaluation_periods" {
+  description = "Number of periods to evaluate for the Step Functions failure alarm."
+  type        = number
+  default     = 1
+}
+
+variable "step_functions_datapoints_to_alarm" {
+  description = "Number of datapoints that must breach the threshold to trigger the Step Functions alarm."
+  type        = number
+  default     = 1
+}
+
+variable "step_functions_period_seconds" {
+  description = "Period, in seconds, over which the Step Functions metric is evaluated."
+  type        = number
+  default     = 300
+}
+
+variable "step_functions_treat_missing_data" {
+  description = "How missing data is treated for the Step Functions alarm."
+  type        = string
+  default     = "notBreaching"
+}
+
+variable "redshift_workgroup_name" {
+  description = "Name of the Redshift Serverless workgroup monitored for RPU utilization."
+  type        = string
+}
+
+variable "redshift_rpu_utilization_threshold" {
+  description = "Average RPU utilization percentage that triggers the alarm."
+  type        = number
+  default     = 80
+}
+
+variable "redshift_rpu_evaluation_periods" {
+  description = "Number of periods to evaluate for the Redshift RPU alarm."
+  type        = number
+  default     = 1
+}
+
+variable "redshift_rpu_datapoints_to_alarm" {
+  description = "Number of datapoints that must breach the threshold to trigger the Redshift alarm."
+  type        = number
+  default     = 1
+}
+
+variable "redshift_rpu_period_seconds" {
+  description = "Period, in seconds, over which the Redshift RPU metric is evaluated."
+  type        = number
+  default     = 300
+}
+
+variable "redshift_rpu_treat_missing_data" {
+  description = "How missing data is treated for the Redshift RPU alarm."
+  type        = string
+  default     = "notBreaching"
+}
+
+variable "send_ok_actions" {
+  description = "Whether to send OK notifications to the same SNS topic."
+  type        = bool
+  default     = false
+}

--- a/modules/pipeline/README.md
+++ b/modules/pipeline/README.md
@@ -117,9 +117,12 @@ state paths) through Step Functions overrides.
 | ------ | ----------- |
 | `lambda_function_arns` | Map of Lambda function ARNs keyed by logical name. |
 | `sns_topic_arn` | Notification topic ARN for pipeline alerts. |
-| `sns_subscription_arn` | ARN of the Lambda subscription attached to the topic. |
 | `dbt_repository_url` | ECR repository URL for the dbt runner image. |
 | `dbt_task_definition_arn` | ECS task definition ARN for Fargate executions. |
 | `state_machine_arn` | Step Functions state machine ARN. |
 | `event_rule_arn` | EventBridge rule ARN for scheduled executions. |
 | `manual_start_policy_arn` | IAM policy ARN that grants manual start privileges. |
+
+> **Note:** SNS subscriptions and CloudWatch alarms are managed by
+> [`modules/operations`](../operations/README.md) so that alerting
+> configuration lives alongside the broader operations tooling.

--- a/modules/pipeline/main.tf
+++ b/modules/pipeline/main.tf
@@ -93,24 +93,6 @@ resource "aws_sns_topic" "pipeline" {
   tags = var.tags
 }
 
-resource "aws_lambda_permission" "allow_sns_notify" {
-  statement_id  = "AllowExecutionFromSnsNotify"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.pipeline["notify"].function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.pipeline.arn
-}
-
-resource "aws_sns_topic_subscription" "notify" {
-  topic_arn = aws_sns_topic.pipeline.arn
-  protocol  = "lambda"
-  endpoint  = aws_lambda_function.pipeline["notify"].arn
-
-  raw_message_delivery = var.sns_subscription_raw_message_delivery
-
-  depends_on = [aws_lambda_permission.allow_sns_notify]
-}
-
 resource "aws_ecr_repository" "dbt" {
   name                 = var.dbt_repository_name
   force_delete         = var.dbt_repository_force_delete

--- a/modules/pipeline/outputs.tf
+++ b/modules/pipeline/outputs.tf
@@ -8,11 +8,6 @@ output "sns_topic_arn" {
   value       = aws_sns_topic.pipeline.arn
 }
 
-output "sns_subscription_arn" {
-  description = "ARN of the Lambda subscription attached to the notification topic."
-  value       = aws_sns_topic_subscription.notify.arn
-}
-
 output "dbt_repository_url" {
   description = "URL of the ECR repository that stores the dbt runner image."
   value       = aws_ecr_repository.dbt.repository_url

--- a/modules/pipeline/variables.tf
+++ b/modules/pipeline/variables.tf
@@ -103,12 +103,6 @@ variable "sns_topic_name" {
   type        = string
 }
 
-variable "sns_subscription_raw_message_delivery" {
-  description = "Whether the Lambda subscription receives raw SNS messages."
-  type        = bool
-  default     = false
-}
-
 variable "state_machine_name" {
   description = "Name assigned to the Step Functions state machine."
   type        = string

--- a/operations/README.md
+++ b/operations/README.md
@@ -1,0 +1,33 @@
+# Operations Runbook (Minimal)
+
+This runbook describes the first-response flow when the DPC learning pipeline raises an alert via the `dpc-learning-alerts` SNS topic. It focuses on quickly restoring the daily ELT batch while capturing enough context for downstream review.
+
+## 1. Initial triage
+
+1. Review the CloudWatch alarm notification to confirm the alarm name, environment, and triggering metric.
+2. Inspect the Step Functions execution history for the `dpc-pipeline` state machine and pinpoint the failed step.
+3. For data movement issues, open the latest Lambda logs (especially `dpc-validate-manifest` and `dpc-copy-raw`).
+4. For transformation failures, review the ECS task logs emitted by the dbt runner.
+
+## 2. Recovery actions
+
+- **Step Functions failure**: Re-run the most recent execution from the Step Functions console after correcting the root cause. Use the same input payload when possible.
+- **Corrupted S3 source object**: Replace or delete the problematic file under the `raw/` prefix, then re-trigger the pipeline.
+- **dbt model failure**: Inspect the dbt logs under the ECS task output or `target/run_results.json`. Patch the SQL model locally, push a fix if required, and re-run the affected selector before re-running the full pipeline.
+- **Redshift capacity pressure**: Check the Redshift Serverless workgroup activity. Abort runaway queries if necessary, temporarily raise the RPU limit, and schedule a follow-up optimization.
+
+## 3. Post-incident follow-up
+
+1. Document the event summary, owner, and resolution steps in the shared incident log.
+2. Attach relevant CloudWatch log excerpts or dbt artifacts for later analysis.
+3. Evaluate whether new tests, monitoring rules, or automation are needed.
+
+## 4. Knowledge base ownership
+
+We will decide between Confluence and Notion as the long-term runbook repository after the learning phase completes. Until then, keep this Markdown file updated alongside infrastructure changes so that operators have an up-to-date quick-reference.
+
+## 5. Useful commands
+
+- Re-run pipeline: `aws stepfunctions start-execution --state-machine-arn <arn> --input file://payload.json`
+- Download latest dbt logs: `aws logs tail /aws/ecs/dpc-dbt-runner --since 1h`
+- Replace S3 object: `aws s3 cp path/to/fix.csv s3://dpc-learning-data-<env>/raw/`


### PR DESCRIPTION
## Summary
- add a Terraform operations module that creates Step Functions failure and Redshift RPU CloudWatch alarms and wires them into the existing SNS topic
- move the notify Lambda subscription responsibility from the pipeline module to the new operations module and document the separation of concerns
- document a minimal runbook and introduce a CI workflow that runs Terraform formatting/validation/plan plus dbt deps+compile

## Testing
- not run (Terraform binary download blocked in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68f874b6ffa88329bb91eecfcb66ff00